### PR TITLE
Add tile layer support, layer control, and shape helpers

### DIFF
--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -1,90 +1,98 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="utf-8" />
     <title>{{ title }}</title>
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
     <link href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css" rel="stylesheet" />
     <style>
-        body {
-            margin: 0;
-            padding: 0;
-        }
-
-        #map {
-            width: 100%;
-            height: 500px;
-        }
-
-            {
-                {
-                custom_css|safe
-            }
-        }
+        body { margin: 0; padding: 0; }
+        #map { width: 100%; height: 500px; }
+{{ custom_css | safe }}
     </style>
 </head>
-
 <body>
-    <div id="map"></div>
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"></script>
-    <script>
-        // Initialize map
-        var map = new maplibregl.Map({
-            container: 'map',
-            style: {{ map_style| tojson }},
-        center: { { center | tojson } },
-        zoom: { { zoom } }
-        });
+<div id="map"></div>
+<script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"></script>
+<script>
+var map = new maplibregl.Map({
+    container: 'map',
+    style: {{ map_style | tojson }},
+    center: {{ center | tojson }},
+    zoom: {{ zoom }}
+});
 
-        // Add controls
-        {% for ctrl in controls %}
-        {% if ctrl.type == "navigation" %}
-        map.addControl(new maplibregl.NavigationControl(), "{{ ctrl.position }}");
-        {% elif ctrl.type == "scale" %}
-        map.addControl(new maplibregl.ScaleControl({{ ctrl.options | tojson }}), "{{ ctrl.position }}");
-        {% elif ctrl.type == "fullscreen" %}
-        map.addControl(new maplibregl.FullscreenControl(), "{{ ctrl.position }}");
-        {% endif %}
-        {% endfor %}
+// Add controls
+{% for ctrl in controls %}
+{% if ctrl.type == "navigation" %}
+map.addControl(new maplibregl.NavigationControl(), "{{ ctrl.position }}");
+{% elif ctrl.type == "scale" %}
+map.addControl(new maplibregl.ScaleControl({{ ctrl.options | tojson }}), "{{ ctrl.position }}");
+{% elif ctrl.type == "fullscreen" %}
+map.addControl(new maplibregl.FullscreenControl(), "{{ ctrl.position }}");
+{% endif %}
+{% endfor %}
 
-        // Add layers
-        map.on('load', function () {
-            // Add sources
-            {% for source in sources %}
-            map.addSource("{{ source.name }}", {{ source.definition | tojson | safe }});
-            {% endfor %}
+map.on('load', function() {
+    // Add sources
+    {% for source in sources %}
+    map.addSource("{{ source.name }}", {{ source.definition | tojson | safe }});
+    {% endfor %}
 
-            // Add layers
-            {% for layer in layers %}
-            map.addLayer({{ layer.definition | tojson | safe }}, "{{ layer.before }}" || undefined);
-            {% endfor %}
+    // Add layers
+    {% for layer in layers %}
+    map.addLayer({{ layer.definition | tojson | safe }}{% if layer.before %}, "{{ layer.before }}"{% endif %});
+    {% endfor %}
 
-        // Add popups
-        {% for popup in popups %}
-        // Create a popup instance
-        var popup_{{ loop.index }} = new maplibregl.Popup({{ popup.options | tojson }})
-            .setHTML(`{{ popup.html }}`);
+    // Popups
+    {% for popup in popups %}
+    var popup_{{ loop.index }} = new maplibregl.Popup({{ popup.options | tojson }}).setHTML(`{{ popup.html }}`);
+    {% if popup.coordinates %}
+    popup_{{ loop.index }}.setLngLat({{ popup.coordinates | tojson }}).addTo(map);
+    {% endif %}
+    {% if popup.layer_id and popup.events %}
+    map.on('{{ popup.events|first }}', '{{ popup.layer_id }}', function(e) {
+        popup_{{ loop.index }}
+            .setLngLat(e.lngLat)
+            .setHTML(`{{ popup.html }}`)
+            .addTo(map);
+    });
+    {% endif %}
+    {% endfor %}
 
-        {% if popup.coordinates %}
-            // If popup is fixed at certain coordinates
-            popup_{ { loop.index } }.setLngLat({{ popup.coordinates | tojson }}).addTo(map);
-        {% endif %}
+    {% if layer_control %}
+    var layerControl = document.createElement('div');
+    layerControl.id = 'layer-control';
+    layerControl.style.background = 'white';
+    layerControl.style.padding = '10px';
+    layerControl.style.position = 'absolute';
+    layerControl.style.top = '10px';
+    layerControl.style.right = '10px';
+    layerControl.style.zIndex = '1';
+    layerControl.style.fontFamily = 'sans-serif';
 
-        {% if popup.layer_id and popup.events %}
-        // If popup is triggered by layer event (e.g., click)
-        map.on('{{ popup.events|first }}', '{{ popup.layer_id }}', function (e) {
-                popup_{ { loop.index } }
-                    .setLngLat(e.lngLat)
-                .setHTML(`{{ popup.html }}`)
-                .addTo(map);
-        });
-        {% endif %}
-        {% endfor %}
-        });
+    {% for t in tile_layers %}
+    (function(){
+        var input = document.createElement('input');
+        input.type = 'checkbox';
+        input.id = 'chk_{{ t.id }}';
+        input.checked = true;
+        input.onchange = function(){
+            map.setLayoutProperty('{{ t.id }}', 'visibility', this.checked ? 'visible' : 'none');
+        };
+        var label = document.createElement('label');
+        label.htmlFor = input.id;
+        label.innerText = '{{ t.name }}';
+        layerControl.appendChild(input);
+        layerControl.appendChild(label);
+        layerControl.appendChild(document.createElement('br'));
+    })();
+    {% endfor %}
+    map.getContainer().appendChild(layerControl);
+    {% endif %}
+});
 
-        { { extra_js | safe } }
-    </script>
+{{ extra_js | safe }}
+</script>
 </body>
-
 </html>

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,5 +1,18 @@
+import os
+import sys
 import unittest
-from maplibreum.core import Map, Marker, GeoJson
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from maplibreum.core import (
+    Map,
+    Marker,
+    GeoJson,
+    Circle,
+    CircleMarker,
+    PolyLine,
+    LayerControl,
+)
 
 
 class TestFeatures(unittest.TestCase):
@@ -45,6 +58,24 @@ class TestFeatures(unittest.TestCase):
             m.layers[0]["definition"]["paint"]["fill-color"],
             ["get", "color", ["properties"]],
         )
+
+    def test_tile_layer_and_control(self):
+        m = Map()
+        m.add_tile_layer(
+            "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+            name="OSM",
+            attribution="© OpenStreetMap contributors",
+        )
+        LayerControl().add_to(m)
+        self.assertEqual(len(m.tile_layers), 1)
+        self.assertTrue(m.layer_control)
+
+    def test_shapes(self):
+        m = Map()
+        Circle([0, 0], radius=1000).add_to(m)
+        CircleMarker([1, 1], radius=5).add_to(m)
+        PolyLine([[0, 0], [1, 1]]).add_to(m)
+        self.assertEqual(len(m.layers), 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `Map.add_tile_layer` for raster overlays
- introduce `Circle`, `CircleMarker`, `PolyLine`, and `LayerControl`
- update HTML template to render tile layers and a simple control UI
- test tile layers, shapes, and layer control

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894fbad384c832f9bd27d9b12f5105f