### PR TITLE
Add map marker helper

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -126,6 +126,28 @@ class Map:
             }
         )
 
+    def add_marker(self, coordinates, popup=None, color="#007cbf"):
+        """Add a marker to the map.
+
+        Parameters
+        ----------
+        coordinates : list or tuple
+            ``[lng, lat]`` pair specifying where to place the marker.
+        popup : str, optional
+            Optional HTML content for a popup attached to the marker.
+        color : str, optional
+            Hex string defining the marker's color. Defaults to ``"#007cbf"``.
+
+        Returns
+        -------
+        Marker
+            The marker instance that was added to the map.
+        """
+
+        marker = Marker(coordinates=coordinates, popup=popup, color=color)
+        marker.add_to(self)
+        return marker
+
     def add_circle_layer(
         self, name, source, paint=None, layout=None, before=None, filter=None
     ):


### PR DESCRIPTION
## Summary
- implement `Map.add_marker` to quickly add a colored marker with optional popup

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894fb7cdd8c832f8c1cee1622ecd3f9