### PR TITLE
feat: add marker wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ from maplibreum import Map
 # Create a map centered at a specific location
 m = Map(center=[-23.5505, -46.6333], zoom=10)
 
-# Add a marker
+# Add a marker at the map center
 m.add_marker(popup="Hello, MapLibre!")
+
+# Or specify coordinates for the marker
+m.add_marker(coordinates=[-23.55, -46.63], popup="Another marker")
 
 # Save the map to an HTML file
 m.save("my_map.html")

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -126,6 +126,25 @@ class Map:
             }
         )
 
+    def add_marker(self, coordinates=None, popup=None, color="#007cbf"):
+        """Add a marker to the map.
+
+        Parameters
+        ----------
+        coordinates : list or tuple, optional
+            [lng, lat] pair where the marker will be placed. Defaults to the
+            map's center if not provided.
+        popup : str, optional
+            HTML content for a popup bound to the marker.
+        color : str, optional
+            Color of the marker, defaults to MapLibre blue.
+        """
+        if coordinates is None:
+            coordinates = self.center
+        marker = Marker(coordinates=coordinates, popup=popup, color=color)
+        marker.add_to(self)
+        return marker
+
     def add_circle_layer(
         self, name, source, paint=None, layout=None, before=None, filter=None
     ):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -18,6 +18,13 @@ class TestFeatures(unittest.TestCase):
         self.assertEqual(len(m.popups), 1)
         self.assertEqual(m.layers[0]["definition"]["paint"]["circle-color"], "red")
 
+    def test_add_marker_wrapper(self):
+        m = Map()
+        m.add_marker(coordinates=[-74.5, 40], popup="Wrapper marker", color="green")
+        self.assertEqual(len(m.layers), 1)
+        self.assertEqual(len(m.popups), 1)
+        self.assertEqual(m.layers[0]["definition"]["paint"]["circle-color"], "green")
+
     def test_geojson(self):
         m = Map()
         geojson_data = {


### PR DESCRIPTION
## Summary
- add Map.add_marker wrapper for simple marker addition
- document marker usage in README
- cover add_marker with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894fb7564c4832f9fa68b041422d2c5