### PR TITLE
chore: drop templates package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
 "Issues" = "https://github.com/kauevestena/maplibreum_prototype/issues"
 
 [tool.setuptools]
-packages = ["maplibreum", "maplibreum.templates"]
+packages = ["maplibreum"]
+include-package-data = false
 
 [tool.setuptools.package-data]
 maplibreum = ["templates/*.html"]


### PR DESCRIPTION
## Summary
- remove `maplibreum.templates` from setuptools packages
- disable implicit package data, rely on package-data to ship HTML templates

## Testing
- `python -m build`
- `pip install dist/maplibreum-0.1.0-py3-none-any.whl --force-reinstall`
- `pytest` *(fails: jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'endfor')*

------
https://chatgpt.com/codex/tasks/task_b_689763186af8832fa8eb2c4c2bba1855