### PR TITLE
Add marker clustering support

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -1,4 +1,4 @@
-from .core import Map, Marker, GeoJson
+from .core import Map, Marker, GeoJson, MarkerCluster
 
-__all__ = ["Map", "Marker", "GeoJson"]
+__all__ = ["Map", "Marker", "GeoJson", "MarkerCluster"]
 

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -104,6 +104,23 @@ map.on('load', function() {
     });
     map.getContainer().appendChild(layerControl);
     {% endif %}
+
+    {% for cl in cluster_layers %}
+    map.on('click', '{{ cl.cluster_layer }}', function(e) {
+        var features = map.queryRenderedFeatures(e.point, { layers: ['{{ cl.cluster_layer }}'] });
+        var clusterId = features[0].properties.cluster_id;
+        map.getSource('{{ cl.source }}').getClusterExpansionZoom(clusterId, function(err, zoom) {
+            if (err) return;
+            map.easeTo({ center: features[0].geometry.coordinates, zoom: zoom });
+        });
+    });
+    map.on('mouseenter', '{{ cl.cluster_layer }}', function() {
+        map.getCanvas().style.cursor = 'pointer';
+    });
+    map.on('mouseleave', '{{ cl.cluster_layer }}', function() {
+        map.getCanvas().style.cursor = '';
+    });
+    {% endfor %}
 });
 
     {{ extra_js | safe }}

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,0 +1,40 @@
+import pytest
+
+from maplibreum.core import Map, Marker, MarkerCluster
+
+
+def test_marker_cluster_source_and_layers():
+    m = Map()
+    cluster = MarkerCluster().add_to(m)
+    # add markers via both Marker and Map.add_marker
+    Marker(coordinates=[0, 0]).add_to(cluster)
+    m.add_marker(coordinates=[1, 1], cluster=cluster)
+
+    # only cluster layers should be present
+    assert len(m.layers) == 3
+
+    # verify source parameters
+    source = next(s for s in m.sources if s["name"] == cluster.source_name)
+    assert source["definition"]["cluster"] is True
+    assert source["definition"]["clusterRadius"] == 50
+
+    # verify cluster layers definitions
+    cluster_layer = next(
+        l for l in m.layers if l["definition"]["id"] == cluster.cluster_layer_id
+    )
+    assert cluster_layer["definition"]["filter"] == ["has", "point_count"]
+
+    count_layer = next(
+        l for l in m.layers if l["definition"]["id"] == cluster.count_layer_id
+    )
+    assert count_layer["definition"]["type"] == "symbol"
+    assert count_layer["definition"]["filter"] == ["has", "point_count"]
+
+    unclustered_layer = next(
+        l for l in m.layers if l["definition"]["id"] == cluster.unclustered_layer_id
+    )
+    assert unclustered_layer["definition"]["filter"] == [
+        "!",
+        ["has", "point_count"],
+    ]
+


### PR DESCRIPTION
## Summary
- implement `MarkerCluster` for MapLibre-based marker clustering
- allow markers to join clusters via `Marker` or `Map.add_marker`
- render clustered sources and cluster interactions in the template
- test marker clustering layers and source parameters

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c28aadd68832f9d40590bc1edcf60