### PR TITLE
Add layer grouping support and controls

### DIFF
--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -79,6 +79,8 @@ map.on('load', function() {
     {% endfor %}
     ];
 
+    var layerGroups = {{ layer_groups | tojson | safe }};
+
     {% if tile_layers %}
     // Hide all but the first tile layer
     tileLayers.forEach(function(tl, idx) {
@@ -102,6 +104,23 @@ map.on('load', function() {
         });
         layerControl.appendChild(link);
     });
+
+    for (var group in layerGroups) {
+        var label = document.createElement('label');
+        var checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = true;
+        checkbox.setAttribute('data-group', group);
+        checkbox.addEventListener('change', function(e) {
+            var grp = e.target.getAttribute('data-group');
+            layerGroups[grp].forEach(function(id) {
+                map.setLayoutProperty(id, 'visibility', e.target.checked ? 'visible' : 'none');
+            });
+        });
+        label.appendChild(checkbox);
+        label.appendChild(document.createTextNode(group));
+        layerControl.appendChild(label);
+    }
     map.getContainer().appendChild(layerControl);
     {% endif %}
 });

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,0 +1,21 @@
+from maplibreum.core import Map, Circle, CircleMarker, FeatureGroup, LayerControl
+
+
+def test_feature_group_render_and_toggle():
+    m = Map()
+    fg = FeatureGroup("TestGroup")
+    fg.add_layer(Circle([0, 0], radius=1000))
+    fg.add_layer(CircleMarker([1, 1], radius=5))
+    fg.add_to(m)
+    LayerControl().add_to(m)
+
+    html = m.render()
+
+    # group name should be present in rendered HTML
+    assert "TestGroup" in html
+    assert "layerGroups" in html
+
+    # all layer ids belonging to the group should appear in the layerGroups mapping
+    for layer_id in m.layer_groups["TestGroup"]:
+        assert layer_id in html
+


### PR DESCRIPTION
## Summary
- Support grouping layers via new `LayerGroup` and `FeatureGroup`
- Enhance `LayerControl` and map template to toggle layer groups
- Add tests verifying grouped layer rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c2881e5f0832f95e2421bd106f78e