### PR TITLE
Add custom icon support for markers

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -1,4 +1,4 @@
-from .core import Map, Marker, GeoJson
+from .core import Map, Marker, GeoJson, Icon
 
-__all__ = ["Map", "Marker", "GeoJson"]
+__all__ = ["Map", "Marker", "GeoJson", "Icon"]
 

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -45,6 +45,14 @@ map.addControl(new maplibregl.FullscreenControl(), "{{ ctrl.position }}");
 {% endfor %}
 
 map.on('load', function() {
+    // Load icons
+    {% for icon in icons %}
+    map.loadImage("{{ icon.icon_url }}", function(error, image) {
+        if (error) throw error;
+        map.addImage("{{ icon.id }}", image);
+    });
+    {% endfor %}
+
     // Add sources
     {% for source in sources %}
     map.addSource("{{ source.name }}", {{ source.definition | tojson | safe }});

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -7,6 +7,7 @@ from maplibreum.core import (
     CircleMarker,
     PolyLine,
     LayerControl,
+    Icon,
 )
 
 
@@ -33,6 +34,24 @@ def test_add_marker_wrapper():
     assert len(m.layers) == 1
     assert len(m.popups) == 1
     assert m.layers[0]["definition"]["paint"]["circle-color"] == "green"
+
+
+def test_marker_with_icon():
+    m = Map()
+    icon = Icon(
+        icon_url="https://example.com/icon.png",
+        icon_size=0.5,
+        icon_anchor="bottom",
+    )
+    m.add_marker(coordinates=[-74.5, 40], popup="Icon marker", icon=icon)
+    assert len(m.layers) == 1
+    layer_def = m.layers[0]["definition"]
+    assert layer_def["type"] == "symbol"
+    layout = layer_def["layout"]
+    assert layout["icon-image"] == icon.id
+    assert layout["icon-size"] == 0.5
+    assert layout["icon-anchor"] == "bottom"
+    assert len(m.icons) == 1
 
 
 def test_geojson():


### PR DESCRIPTION
## Summary
- add `Icon` class for marker image customization
- allow markers and `add_marker` to use icons
- load custom icons in map template and apply to symbol layers
- test icon layer definitions

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c2876d510832fa98ef2666d7dd89c