### PR TITLE
Expose layer utilities in package interface

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -1,4 +1,20 @@
-from .core import Map, Marker, GeoJson
+from .core import (
+    Map,
+    Marker,
+    GeoJson,
+    Circle,
+    CircleMarker,
+    PolyLine,
+    LayerControl,
+)
 
-__all__ = ["Map", "Marker", "GeoJson"]
+__all__ = [
+    "Map",
+    "Marker",
+    "GeoJson",
+    "Circle",
+    "CircleMarker",
+    "PolyLine",
+    "LayerControl",
+]
 


### PR DESCRIPTION
## Summary
- Re-export Circle, CircleMarker, PolyLine, and LayerControl from the top-level package
- Update `__all__` to include these layer classes for direct imports

## Testing
- `pytest`
- `python - <<'PY'
from maplibreum import Circle
print(Circle)
PY`


------
https://chatgpt.com/codex/tasks/task_b_689c28ca7500832f99a62474cb53b91d