### PR TITLE
Add heatmap layer helper with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ m.add_marker(popup="Hello, MapLibre!")
 # Or specify coordinates for the marker
 m.add_marker(coordinates=[-23.55, -46.63], popup="Another marker")
 
+# Add a heatmap layer from GeoJSON points
+geojson = {"type": "FeatureCollection", "features": []}
+source = {"type": "geojson", "data": geojson}
+m.add_heatmap_layer("heat", source)
+
 # Save the map to an HTML file
 m.save("my_map.html")
 ```

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -219,6 +219,63 @@ class Map:
             layer_definition["filter"] = filter
         self.add_layer(layer_definition, source=source, before=before)
 
+    def add_heatmap_layer(
+        self, name, source, paint=None, layout=None, before=None, filter=None
+    ):
+        """
+        Add a heatmap layer to the map.
+
+        Parameters
+        ----------
+        name : str
+            Layer identifier.
+        source : dict or str
+            Source definition or the name of an existing source.
+        paint : dict, optional
+            Heatmap paint properties. Missing properties fall back to sensible
+            defaults.
+        layout : dict, optional
+            Layout properties for the layer.
+        before : str, optional
+            ID of an existing layer before which this layer should be placed.
+        filter : list, optional
+            MapLibre filter expression.
+        """
+        default_paint = {
+            "heatmap-radius": 20,
+            "heatmap-intensity": 1,
+            "heatmap-opacity": 1,
+            "heatmap-color": [
+                "interpolate",
+                ["linear"],
+                ["heatmap-density"],
+                0,
+                "rgba(0,0,255,0)",
+                0.2,
+                "blue",
+                0.4,
+                "cyan",
+                0.6,
+                "lime",
+                0.8,
+                "yellow",
+                1,
+                "red",
+            ],
+        }
+        if paint:
+            default_paint.update(paint)
+        layer_definition = {
+            "id": name,
+            "type": "heatmap",
+            "paint": default_paint,
+        }
+        if layout:
+            layer_definition["layout"] = layout
+        if filter:
+            layer_definition["filter"] = filter
+        self.add_layer(layer_definition, source=source, before=before)
+
     def add_symbol_layer(
         self, name, source, paint=None, layout=None, before=None, filter=None
     ):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -53,6 +53,19 @@ def test_shape_layers(map_instance):
     assert types == ["circle", "line", "fill"]
 
 
+def test_heatmap_layer(map_instance):
+    source = {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}}
+    map_instance.add_heatmap_layer("heat", source)
+    layer = map_instance.layers[0]["definition"]
+    assert layer["type"] == "heatmap"
+    assert layer["paint"]["heatmap-radius"] == 20
+
+    map_instance.add_heatmap_layer("heat_custom", source, paint={"heatmap-radius": 5})
+    custom = map_instance.layers[1]["definition"]
+    assert custom["paint"]["heatmap-radius"] == 5
+    assert custom["paint"]["heatmap-opacity"] == 1
+
+
 def test_popups(map_instance):
     map_instance.add_popup("<b>Hi</b>", coordinates=[1, 2])
     assert len(map_instance.popups) == 1


### PR DESCRIPTION
## Summary
- add `add_heatmap_layer` to `Map` for constructing heatmap layers with sensible defaults
- document heatmap usage in README
- test heatmap layer creation and paint overrides

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c2458963c832f875a3ae30b290ccc