### PR TITLE
Add legend support to Map rendering

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -1,4 +1,4 @@
-from .core import Map, Marker, GeoJson
+from .core import Map, Marker, GeoJson, Legend
 
-__all__ = ["Map", "Marker", "GeoJson"]
+__all__ = ["Map", "Marker", "GeoJson", "Legend"]
 

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -50,6 +50,7 @@ class Map:
         self.extra_js = extra_js
         self.custom_css = custom_css
         self.layer_control = False
+        self.legend = None
 
         template_dir = os.path.join(os.path.dirname(__file__), "templates")
         self.env = Environment(loader=FileSystemLoader(template_dir))
@@ -174,6 +175,10 @@ class Map:
         marker.add_to(self)
         return marker
 
+    def add_legend(self, legend):
+        """Register a legend instance for this map."""
+        self.legend = legend
+
     def add_circle_layer(
         self, name, source, paint=None, layout=None, before=None, filter=None
     ):
@@ -251,6 +256,7 @@ class Map:
             tile_layers=self.tile_layers,
             layer_control=self.layer_control,
             popups=self.popups,
+            legend_html=self.legend.render() if self.legend else "",
             extra_js=self.extra_js,
             custom_css=final_custom_css,
         )
@@ -566,5 +572,27 @@ class LayerControl:
 
     def add_to(self, map_instance):
         map_instance.layer_control = True
+        return self
+
+
+class Legend:
+    """Map legend supporting raw HTML or label/color pairs."""
+
+    def __init__(self, content):
+        if isinstance(content, str):
+            self._html = content
+        else:
+            items = []
+            for label, color in content:
+                items.append(
+                    f'<div><span style="background:{color}"></span>{label}</div>'
+                )
+            self._html = "".join(items)
+
+    def render(self):
+        return self._html
+
+    def add_to(self, map_instance):
+        map_instance.add_legend(self)
         return self
 

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -16,12 +16,39 @@
             height: 500px;
         }
 
+        .maplibreum-legend {
+            position: absolute;
+            bottom: 10px;
+            left: 10px;
+            background: rgba(255, 255, 255, 0.8);
+            padding: 6px;
+            font-size: 12px;
+            border-radius: 4px;
+        }
+
+        .maplibreum-legend div {
+            display: flex;
+            align-items: center;
+            margin-bottom: 4px;
+        }
+
+        .maplibreum-legend span {
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            margin-right: 4px;
+        }
+
         {{ custom_css | safe }}
 
     </style>
 </head>
 <body>
-    <div id="map"></div>
+    <div id="map">
+    {% if legend_html %}
+        <div class="maplibreum-legend">{{ legend_html | safe }}</div>
+    {% endif %}
+    </div>
     <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"></script>
     <script>
         // Initialize map

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,5 @@
 import pytest
-from maplibreum.core import Map, GeoJson
+from maplibreum.core import Map, GeoJson, Legend
 
 
 @pytest.fixture
@@ -86,3 +86,13 @@ def test_geojson_styling(map_instance):
     paint = map_instance.layers[0]["definition"]["paint"]
     assert paint["fill-color"] == ["get", "fillColor", ["properties"]]
     assert paint["fill-opacity"] == ["get", "fillOpacity", ["properties"]]
+
+
+def test_legend_rendering():
+    m = Map()
+    legend = Legend([("A", "#ff0000"), ("B", "#00ff00")])
+    legend.add_to(m)
+    html = m.render()
+    assert "maplibreum-legend" in html
+    assert "#ff0000" in html
+    assert "A" in html


### PR DESCRIPTION
## Summary
- add `Legend` class capable of rendering from HTML or label/color pairs
- enable `Map` to register a legend and render it into map template
- style legend container in `map_template.html`
- test that legend HTML is embedded in map render output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c28b149b4832f91efeba789981624