### PR TITLE
Add Rectangle shape built on Polygon

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -793,6 +793,50 @@ class Polygon:
             map_instance.add_popup(html=self.popup, layer_id=layer_id)
 
 
+class Rectangle:
+    """Axis-aligned rectangle defined by southwest and northeast corners."""
+
+    def __init__(
+        self,
+        southwest,
+        northeast,
+        color="#3388ff",
+        weight=2,
+        fill=True,
+        fill_color=None,
+        fill_opacity=0.5,
+        popup=None,
+    ):
+        self.southwest = southwest
+        self.northeast = northeast
+        self.color = color
+        self.weight = weight
+        self.fill = fill
+        self.fill_color = fill_color if fill_color else color
+        self.fill_opacity = fill_opacity
+        self.popup = popup
+
+    def add_to(self, map_instance):
+        sw_lng, sw_lat = self.southwest
+        ne_lng, ne_lat = self.northeast
+        coords = [
+            [sw_lng, sw_lat],
+            [sw_lng, ne_lat],
+            [ne_lng, ne_lat],
+            [ne_lng, sw_lat],
+        ]
+        polygon = Polygon(
+            coords,
+            color=self.color,
+            weight=self.weight,
+            fill=self.fill,
+            fill_color=self.fill_color,
+            fill_opacity=self.fill_opacity,
+            popup=self.popup,
+        )
+        polygon.add_to(map_instance)
+
+
 class LayerControl:
     """Simple layer control to toggle tile layers."""
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -7,6 +7,7 @@ from maplibreum.core import (
     CircleMarker,
     PolyLine,
     Polygon,
+    Rectangle,
     LayerControl,
 )
 
@@ -184,3 +185,27 @@ def test_shapes():
     assert polygon_fill["definition"]["paint"]["fill-color"] == "blue"
     assert polygon_outline["definition"]["paint"]["line-color"] == "red"
     assert polygon_outline["definition"]["paint"]["line-width"] == 3
+
+
+def test_rectangle():
+    m = Map()
+    Rectangle([0, 0], [1, 1], color="red", weight=3, fill_color="blue").add_to(m)
+    assert len(m.layers) == 2
+    rect_fill = next(
+        l
+        for l in m.layers
+        if l["definition"]["id"].startswith("polygon_")
+        and l["definition"]["type"] == "fill"
+    )
+    rect_outline = next(
+        l
+        for l in m.layers
+        if l["definition"]["type"] == "line"
+    )
+    assert (
+        rect_outline["definition"]["id"]
+        == f"{rect_fill['definition']['id']}_outline"
+    )
+    assert rect_fill["definition"]["paint"]["fill-color"] == "blue"
+    assert rect_outline["definition"]["paint"]["line-color"] == "red"
+


### PR DESCRIPTION
## Summary
- add Rectangle class that converts bounds to a Polygon and reuses existing fill/outline logic
- test rectangle layer id, fill, and line styling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a1345037f0832fb50747255eb807b7