### PR TITLE
Add icon support for markers

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -1,6 +1,6 @@
-from .core import Map, Marker, GeoJson, Legend
+from .core import Map, Marker, GeoJson, Legend, Icon
 from .choropleth import Choropleth
 
-__all__ = ["Map", "Marker", "GeoJson", "Legend", "Choropleth"]
+__all__ = ["Map", "Marker", "GeoJson", "Legend", "Choropleth", "Icon"]
 
 

--- a/tests/test_marker_icon.py
+++ b/tests/test_marker_icon.py
@@ -1,0 +1,18 @@
+from maplibreum.core import Map, Marker, Icon
+
+
+def test_marker_with_icon_creates_symbol_layer_and_popup():
+    m = Map()
+    icon = Icon(icon_image="custom-icon", icon_size=2.0, icon_anchor="bottom")
+    marker = Marker(coordinates=[-74.5, 40], popup="Icon marker", icon=icon)
+    marker.add_to(m)
+
+    assert m.layers[0]["definition"]["type"] == "symbol"
+    layout = m.layers[0]["definition"]["layout"]
+    assert layout["icon-image"] == "custom-icon"
+    assert layout["icon-size"] == 2.0
+    assert layout["icon-anchor"] == "bottom"
+
+    assert len(m.popups) == 1
+    assert m.popups[0]["html"] == "Icon marker"
+    assert m.popups[0]["layer_id"] == m.layers[0]["id"]


### PR DESCRIPTION
## Summary
- add `Icon` class and support for icon-based markers
- allow `Marker` and `Map.add_marker` to accept `icon`
- test icon markers create symbol layers and maintain popups

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a1368c715c832f9c6f8caed0912b51