### PR TITLE
Add WMS layer support

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -37,6 +37,15 @@ def test_add_tile_layer(map_instance):
     )
 
 
+def test_add_wms_layer(map_instance):
+    map_instance.add_wms_layer("https://example.com/wms", layers="basic")
+    tiles_url = map_instance.sources[0]["definition"]["tiles"][0]
+    assert "service=WMS" in tiles_url
+    assert "layers=basic" in tiles_url
+    assert "bbox={bbox-epsg-3857}" in tiles_url
+    assert map_instance.layers[0]["definition"]["type"] == "raster"
+
+
 def test_add_layer_control(map_instance):
     map_instance.add_control("navigation", "top-left")
     assert map_instance.controls == [


### PR DESCRIPTION
## Summary
- add `add_wms_layer` helper to construct raster tiles from WMS services
- cover WMS integration with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a394f9b4a8832f9c6dfa8a3249d5eb