### PR TITLE
Add ImageOverlay for raster overlays

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -1,6 +1,14 @@
-from .core import Map, Marker, GeoJson, Legend, Icon
+from .core import Map, Marker, GeoJson, Legend, Icon, ImageOverlay
 from .choropleth import Choropleth
 
-__all__ = ["Map", "Marker", "GeoJson", "Legend", "Choropleth", "Icon"]
+__all__ = [
+    "Map",
+    "Marker",
+    "GeoJson",
+    "Legend",
+    "Choropleth",
+    "Icon",
+    "ImageOverlay",
+]
 
 

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -947,6 +947,78 @@ class Rectangle:
         polygon.add_to(map_instance)
 
 
+class ImageOverlay:
+    """Overlay a georeferenced image on the map."""
+
+    def __init__(
+        self,
+        image,
+        bounds=None,
+        coordinates=None,
+        opacity=1.0,
+        attribution=None,
+        name=None,
+    ):
+        """Create an ImageOverlay.
+
+        Parameters
+        ----------
+        image : str
+            URL or local path to the image.
+        bounds : list, optional
+            Bounds of the image as ``[west, south, east, north]`` or
+            ``[[west, south], [east, north]]``.
+        coordinates : list, optional
+            Four corner coordinates of the image specified as
+            ``[[west, north], [east, north], [east, south], [west, south]]``.
+            If provided, ``bounds`` is ignored.
+        opacity : float, optional
+            Opacity of the raster layer, defaults to ``1.0``.
+        attribution : str, optional
+            Attribution text for the source.
+        name : str, optional
+            Layer identifier. If omitted, a unique one is generated.
+        """
+
+        self.image = image
+        self.attribution = attribution
+        self.opacity = opacity
+        self.name = name or f"imageoverlay_{uuid.uuid4().hex}"
+
+        if coordinates is not None:
+            self.coordinates = coordinates
+        elif bounds is not None:
+            if len(bounds) == 2 and all(len(b) == 2 for b in bounds):
+                west, south = bounds[0]
+                east, north = bounds[1]
+            else:
+                west, south, east, north = bounds
+            self.coordinates = [
+                [west, north],
+                [east, north],
+                [east, south],
+                [west, south],
+            ]
+        else:
+            raise ValueError("Either coordinates or bounds must be provided")
+
+    def add_to(self, map_instance):
+        source = {
+            "type": "image",
+            "url": self.image,
+            "coordinates": self.coordinates,
+        }
+        if self.attribution:
+            source["attribution"] = self.attribution
+
+        layer = {"id": self.name, "type": "raster", "source": self.name}
+        if self.opacity is not None:
+            layer["paint"] = {"raster-opacity": self.opacity}
+
+        map_instance.add_layer(layer, source=source)
+        return self
+
+
 class LayerControl:
     """Simple layer control to toggle tile layers."""
 

--- a/tests/test_image_overlay.py
+++ b/tests/test_image_overlay.py
@@ -1,0 +1,28 @@
+import pytest
+from maplibreum.core import Map, ImageOverlay
+
+
+def test_image_overlay_bounds_and_opacity():
+    m = Map()
+    image_url = "https://example.com/image.png"
+    bounds = [-1.0, -2.0, 3.0, 4.0]
+    overlay = ImageOverlay(image_url, bounds=bounds, opacity=0.6, attribution="Demo")
+    overlay.add_to(m)
+
+    assert len(m.sources) == 1
+    src_def = m.sources[0]["definition"]
+    assert src_def["type"] == "image"
+    expected_coords = [
+        [bounds[0], bounds[3]],
+        [bounds[2], bounds[3]],
+        [bounds[2], bounds[1]],
+        [bounds[0], bounds[1]],
+    ]
+    assert src_def["coordinates"] == expected_coords
+    assert src_def["attribution"] == "Demo"
+
+    assert len(m.layers) == 1
+    layer_def = m.layers[0]["definition"]
+    assert layer_def["type"] == "raster"
+    assert layer_def["paint"]["raster-opacity"] == 0.6
+


### PR DESCRIPTION
## Summary
- add ImageOverlay class to display georeferenced images with optional opacity and attribution
- expose ImageOverlay in package exports
- test image overlay integrates with map sources and layers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a395b6780c832f9128f0a24c0dbcdb