### PR TITLE
Remove unused Markup import

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -6,7 +6,6 @@ from urllib.parse import quote
 
 from IPython.display import IFrame, display
 from jinja2 import Environment, FileSystemLoader
-from markupsafe import Markup
 
 
 # Predefined map styles


### PR DESCRIPTION
## Summary
- clean up `core` by dropping unused MarkupSafe import

## Testing
- `flake8 maplibreum` (fails: W391, E501, E303)
- `python -m pyflakes maplibreum/core.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a3b7b118e0832f96781b4ecbea4907