### PR TITLE
Add tooltip support for map elements

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -1,4 +1,4 @@
-from .core import Map, Marker, GeoJson, Legend, Icon, ImageOverlay
+from .core import Map, Marker, GeoJson, Legend, Icon, ImageOverlay, Tooltip
 from .choropleth import Choropleth
 
 __all__ = [
@@ -9,6 +9,7 @@ __all__ = [
     "Choropleth",
     "Icon",
     "ImageOverlay",
+    "Tooltip",
 ]
 
 

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -100,6 +100,19 @@ map.on('load', function() {
     {% endif %}
     {% endfor %}
 
+    // Tooltips
+    {% for tooltip in tooltips %}
+    var tooltip_{{ loop.index }} = new maplibregl.Popup({{ tooltip.options | tojson }});
+    map.on('mouseenter', '{{ tooltip.layer_id }}', function(e) {
+        tooltip_{{ loop.index }}
+            .setLngLat(e.lngLat)
+            .setHTML(`{{ tooltip.text }}`)
+            .addTo(map);
+    });
+    map.on('mouseleave', '{{ tooltip.layer_id }}', function() {
+        tooltip_{{ loop.index }}.remove();
+    });
+    {% endfor %}
 
     // Tile Layers
     var tileLayers = [

--- a/tests/test_tooltip.py
+++ b/tests/test_tooltip.py
@@ -1,0 +1,18 @@
+from maplibreum.core import Map, Marker, Circle, Tooltip
+
+
+def test_marker_tooltip_render():
+    m = Map()
+    Marker([0, 0], tooltip=Tooltip("Marker tip")).add_to(m)
+    assert len(m.tooltips) == 1
+    html = m.render()
+    assert "Marker tip" in html
+    assert "tooltip_1" in html
+    assert '"closeButton": false' in html
+
+
+def test_circle_tooltip_render():
+    m = Map()
+    Circle([0, 0], tooltip=Tooltip("Circle tip")).add_to(m)
+    html = m.render()
+    assert "Circle tip" in html


### PR DESCRIPTION
## Summary
- add Tooltip class and Map.add_tooltip API
- wire tooltips into markers and basic shapes
- render tooltips in template using MapLibre Popups
- test tooltip rendering

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3e858ce5c832f9f7f7e0cbdcfca80