### PR TITLE
Add overlay layer control support

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -56,6 +56,7 @@ class Map:
         self.sources = []
         self.layers = layers if layers is not None else []
         self.tile_layers = []
+        self.overlays = []
         self.popups = popups if popups is not None else []
         self.tooltips = tooltips if tooltips is not None else []
         self.legends = []
@@ -125,6 +126,8 @@ class Map:
             {"id": layer_id, "definition": layer_definition, "before": before}
         )
 
+        return layer_id
+
     def add_tile_layer(self, url, name=None, attribution=None):
         """Add a raster tile layer to the map.
 
@@ -148,6 +151,10 @@ class Map:
         layer = {"id": layer_id, "type": "raster", "source": layer_id}
         self.add_layer(layer, source=source)
         self.tile_layers.append({"id": layer_id, "name": name or layer_id})
+
+    def register_overlay(self, layer_id, name=None):
+        """Register a non-tile overlay layer for the layer control."""
+        self.overlays.append({"id": layer_id, "name": name or layer_id})
 
     def add_wms_layer(
         self,
@@ -421,6 +428,7 @@ class Map:
             controls=self.controls,
             layers=self.layers,
             tile_layers=self.tile_layers,
+            overlays=self.overlays,
             layer_control=self.layer_control,
             popups=self.popups,
             tooltips=self.tooltips,
@@ -1081,10 +1089,21 @@ class ImageOverlay:
 
 
 class LayerControl:
-    """Simple layer control to toggle tile layers."""
+    """Simple layer control to toggle tile and overlay layers."""
+
+    def __init__(self):
+        self.overlays = []
+
+    def add_overlay(self, layer_id, name=None):
+        """Register an overlay layer by its ID and display name."""
+        self.overlays.append({"id": layer_id, "name": name or layer_id})
+        return self
 
     def add_to(self, map_instance):
         map_instance.layer_control = True
+        if self.overlays:
+            for ov in self.overlays:
+                map_instance.register_overlay(ov["id"], ov["name"])
         return self
 
 

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -121,6 +121,13 @@ map.on('load', function() {
     {% endfor %}
     ];
 
+    // Overlay Layers
+    var overlayLayers = [
+    {% for ov in overlays %}
+        { id: "{{ ov.id }}", name: "{{ ov.name }}" },
+    {% endfor %}
+    ];
+
     {% if tile_layers %}
     // Hide all but the first tile layer
     tileLayers.forEach(function(tl, idx) {
@@ -143,6 +150,19 @@ map.on('load', function() {
             });
         });
         layerControl.appendChild(link);
+    });
+
+    overlayLayers.forEach(function(ol) {
+        var label = document.createElement('label');
+        var checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = true;
+        checkbox.addEventListener('change', function(e) {
+            map.setLayoutProperty(ol.id, 'visibility', e.target.checked ? 'visible' : 'none');
+        });
+        label.appendChild(checkbox);
+        label.appendChild(document.createTextNode(' ' + ol.name));
+        layerControl.appendChild(label);
     });
     map.getContainer().appendChild(layerControl);
     {% endif %}

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -163,6 +163,45 @@ def test_tile_layer_and_control():
     assert m.layer_control
 
 
+def test_overlay_layer_control():
+    m = Map()
+    m.add_tile_layer(
+        "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        name="OSM",
+        attribution="© OpenStreetMap contributors",
+    )
+
+    source = {
+        "type": "geojson",
+        "data": {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "properties": {},
+                }
+            ],
+        },
+    }
+    layer_id = m.add_layer(
+        {
+            "id": "points",
+            "type": "circle",
+            "paint": {"circle-radius": 5, "circle-color": "red"},
+        },
+        source=source,
+    )
+    lc = LayerControl()
+    lc.add_overlay(layer_id, "Points")
+    lc.add_to(m)
+    html = m.render()
+    assert "overlayLayers" in html
+    assert "Points" in html
+    assert "checkbox" in html
+    assert "setLayoutProperty(ol.id" in html
+
+
 def test_shapes():
     m = Map()
     Circle([0, 0], radius=1000).add_to(m)


### PR DESCRIPTION
## Summary
- track overlay layers on `Map` and expose registration API through `LayerControl`
- add overlay checkbox UI in `map_template.html`
- test overlay layers toggled independently from base tiles

## Testing
- `pip install -e .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a3eb8d5b78832fbf2a3c1c42c2f5ba