### PR TITLE
Add FeatureGroup and group-aware layer control

### DIFF
--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -124,7 +124,7 @@ map.on('load', function() {
     // Overlay Layers
     var overlayLayers = [
     {% for ov in overlays %}
-        { id: "{{ ov.id }}", name: "{{ ov.name }}" },
+        { id: "{{ ov.id }}", name: "{{ ov.name }}"{% if ov.layers %}, layers: [{% for lid in ov.layers %}"{{ lid }}"{% if not loop.last %}, {% endif %}{% endfor %}]{% endif %} },
     {% endfor %}
     ];
 
@@ -158,7 +158,13 @@ map.on('load', function() {
         checkbox.type = 'checkbox';
         checkbox.checked = true;
         checkbox.addEventListener('change', function(e) {
-            map.setLayoutProperty(ol.id, 'visibility', e.target.checked ? 'visible' : 'none');
+            if (ol.layers) {
+                ol.layers.forEach(function(id) {
+                    map.setLayoutProperty(id, 'visibility', e.target.checked ? 'visible' : 'none');
+                });
+            } else {
+                map.setLayoutProperty(ol.id, 'visibility', e.target.checked ? 'visible' : 'none');
+            }
         });
         label.appendChild(checkbox);
         label.appendChild(document.createTextNode(' ' + ol.name));

--- a/tests/test_feature_group.py
+++ b/tests/test_feature_group.py
@@ -1,0 +1,16 @@
+from maplibreum.core import Map, Marker, FeatureGroup, LayerControl
+
+def test_feature_group_toggles_layers_together():
+    m = Map()
+    fg = FeatureGroup(name="group1")
+    Marker([0, 0]).add_to(fg)
+    Marker([1, 1]).add_to(fg)
+    fg.add_to(m)
+    lc = LayerControl()
+    lc.add_overlay(fg, "Group 1")
+    lc.add_to(m)
+    assert m.overlays[0]["layers"] == fg.layer_ids
+    html = m.render()
+    for lid in fg.layer_ids:
+        assert lid in html
+    assert "ol.layers.forEach" in html


### PR DESCRIPTION
## Summary
- add `FeatureGroup` to group layers and add them to maps together
- enable `LayerControl` and map template to toggle grouped overlays
- test grouped overlays toggling via new `test_feature_group`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a5e65aad60832fadb97bf3e80c02c7