### PR TITLE
Add Mapbox GL Draw support with Python feature access

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -28,6 +28,7 @@ class Tooltip:
 
 
 class Map:
+    _drawn_data = {}
     def __init__(
         self,
         title="MapLibreum Map",
@@ -64,6 +65,8 @@ class Map:
         self.custom_css = custom_css
         self.layer_control = False
         self.cluster_layers = []
+        self.draw_control = False
+        self.draw_control_options = {}
 
         template_dir = os.path.join(os.path.dirname(__file__), "templates")
         self.env = Environment(loader=FileSystemLoader(template_dir))
@@ -85,6 +88,13 @@ class Map:
         self.controls.append(
             {"type": control_type, "position": position, "options": options}
         )
+
+    def add_draw_control(self, options=None):
+        """Enable a draw control on the map."""
+        if options is None:
+            options = {}
+        self.draw_control = True
+        self.draw_control_options = options
 
     def add_legend(self, legend):
         """Add a legend to the map."""
@@ -439,6 +449,9 @@ class Map:
             cluster_layers=self.cluster_layers,
             extra_js=self.extra_js,
             custom_css=final_custom_css,
+            draw_control=self.draw_control,
+            draw_control_options=self.draw_control_options,
+            map_id=self.map_id,
         )
 
     def _repr_html_(self):
@@ -465,6 +478,14 @@ class Map:
     def save(self, filepath):
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(self.render())
+
+    @classmethod
+    def _store_drawn_features(cls, map_id, geojson_str):
+        cls._drawn_data[map_id] = json.loads(geojson_str)
+
+    @property
+    def drawn_features(self):
+        return self._drawn_data.get(self.map_id)
 
 
 class MarkerCluster:

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -5,6 +5,9 @@
     <title>{{ title }}</title>
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
     <link href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css" rel="stylesheet" />
+    {% if draw_control %}
+    <link href="https://unpkg.com/@mapbox/mapbox-gl-draw@latest/dist/mapbox-gl-draw.css" rel="stylesheet" />
+    {% endif %}
     <style>
         body {
             margin: 0;
@@ -52,6 +55,9 @@
         {% endfor %}
     </div>
     <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"></script>
+    {% if draw_control %}
+    <script src="https://unpkg.com/@mapbox/mapbox-gl-draw@latest/dist/mapbox-gl-draw.js"></script>
+    {% endif %}
     <script>
         // Initialize map
         var map = new maplibregl.Map({
@@ -72,6 +78,21 @@ map.addControl(new maplibregl.ScaleControl({{ ctrl.options | tojson }}), "{{ ctr
 map.addControl(new maplibregl.FullscreenControl(), "{{ ctrl.position }}");
 {% endif %}
 {% endfor %}
+
+{% if draw_control %}
+var draw = new MapboxDraw({{ draw_control_options | tojson }});
+map.addControl(draw);
+function updateDrawn() {
+    var data = draw.getAll();
+    if (window.Jupyter && Jupyter.notebook && Jupyter.notebook.kernel) {
+        var cmd = "from maplibreum.core import Map; Map._store_drawn_features('" + "{{ map_id }}" + "', '" + JSON.stringify(data).replace(/'/g, "\\'") + "')";
+        Jupyter.notebook.kernel.execute(cmd);
+    }
+}
+map.on('draw.create', updateDrawn);
+map.on('draw.update', updateDrawn);
+map.on('draw.delete', updateDrawn);
+{% endif %}
 
 map.on('load', function() {
     // Add sources

--- a/tests/test_draw_control.py
+++ b/tests/test_draw_control.py
@@ -1,0 +1,18 @@
+import json
+from maplibreum.core import Map
+
+
+def test_draw_control_snippet():
+    m = Map()
+    m.add_draw_control()
+    html = m.render()
+    assert "mapbox-gl-draw.js" in html
+    assert "new MapboxDraw" in html
+
+
+def test_drawn_features_storage():
+    m = Map()
+    m.add_draw_control()
+    sample = {"type": "FeatureCollection", "features": []}
+    Map._store_drawn_features(m.map_id, json.dumps(sample))
+    assert m.drawn_features == sample


### PR DESCRIPTION
## Summary
- add `Map.add_draw_control` enabling Mapbox GL Draw and storing drawn GeoJSON back in Python
- load Mapbox GL Draw assets and JS callback in template
- test draw control snippet and feature storage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a5eeaa6274832faaa6c6ed3de0ded6