### PR TITLE
Add support for tile subdomains in tile layers

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -128,22 +128,32 @@ class Map:
 
         return layer_id
 
-    def add_tile_layer(self, url, name=None, attribution=None):
+    def add_tile_layer(self, url, name=None, attribution=None, subdomains=None):
         """Add a raster tile layer to the map.
 
         Parameters
         ----------
         url : str
-            Tile URL template.
+            Tile URL template. May contain ``{s}`` as a placeholder for
+            subdomains.
         name : str, optional
             Name of the layer. If omitted, a unique ID is generated.
         attribution : str, optional
             Attribution text for the layer.
+        subdomains : list of str, optional
+            Subdomains to replace ``{s}`` in the URL. If provided and ``{s}``
+            exists in ``url``, multiple tile URLs will be generated.
         """
         layer_id = name or f"tilelayer_{uuid.uuid4().hex}"
+
+        if "{s}" in url and subdomains:
+            tiles = [url.replace("{s}", s) for s in subdomains]
+        else:
+            tiles = [url]
+
         source = {
             "type": "raster",
-            "tiles": [url],
+            "tiles": tiles,
             "tileSize": 256,
         }
         if attribution:

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -151,6 +151,7 @@ def test_tile_layer_and_control():
         "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
         name="OSM",
         attribution="© OpenStreetMap contributors",
+        subdomains=["a", "b", "c"],
     )
     html_no_control = m.render()
     assert "OSM" in html_no_control
@@ -163,12 +164,33 @@ def test_tile_layer_and_control():
     assert m.layer_control
 
 
+def test_tile_layer_subdomains():
+    m = Map()
+    m.add_tile_layer(
+        "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        name="OSM",
+        attribution="© OpenStreetMap contributors",
+        subdomains=["a", "b", "c"],
+    )
+    tiles = m.sources[0]["definition"]["tiles"]
+    assert len(tiles) == 3
+    assert (
+        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png" in tiles
+        and "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png" in tiles
+        and "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png" in tiles
+    )
+    html = m.render()
+    assert "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png" in html
+    assert "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png" in html
+    assert "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png" in html
+
 def test_overlay_layer_control():
     m = Map()
     m.add_tile_layer(
         "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
         name="OSM",
         attribution="© OpenStreetMap contributors",
+        subdomains=["a", "b", "c"],
     )
 
     source = {


### PR DESCRIPTION
## Summary
- allow `Map.add_tile_layer` to accept a `subdomains` list
- expand `{s}` in tile URLs to multiple URLs based on provided subdomains
- test tile layer subdomain expansion and update existing tile layer tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a5eea54220832fb6f36f89c49e2932