### PR TITLE
Add MapLibre version override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ from maplibreum import Map
 # Create a map centered at a specific location
 m = Map(center=[-23.5505, -46.6333], zoom=10)
 
+# Pin a specific MapLibre GL JS version (defaults to 3.4.0)
+m_custom = Map(maplibre_version="2.4.0")
+
 # Add a marker at the map center
 m.add_marker(popup="Hello, MapLibre!")
 

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -43,7 +43,15 @@ class Map:
         tooltips=None,
         extra_js="",
         custom_css="",
+        maplibre_version="3.4.0",
     ):
+        """Initialize a map instance.
+
+        Parameters
+        ----------
+        maplibre_version : str, optional
+            Version of MapLibre GL JS to load. Defaults to "3.4.0".
+        """
         self.title = title
         if map_style in MAP_STYLES:
             self.map_style = MAP_STYLES[map_style]
@@ -63,6 +71,7 @@ class Map:
         self.legends = []
         self.extra_js = extra_js
         self.custom_css = custom_css
+        self.maplibre_version = maplibre_version
         self.layer_control = False
         self.cluster_layers = []
         self.bounds = None
@@ -481,6 +490,7 @@ class Map:
             custom_css=final_custom_css,
             draw_control=self.draw_control,
             draw_control_options=self.draw_control_options,
+            maplibre_version=self.maplibre_version,
             map_id=self.map_id,
         )
 

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>{{ title }}</title>
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-    <link href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css" rel="stylesheet" />
+    <link href="https://unpkg.com/maplibre-gl@{{ maplibre_version }}/dist/maplibre-gl.css" rel="stylesheet" />
     {% if draw_control %}
     <link href="https://unpkg.com/@mapbox/mapbox-gl-draw@latest/dist/mapbox-gl-draw.css" rel="stylesheet" />
     {% endif %}
@@ -54,7 +54,7 @@
         <div class="maplibreum-legend">{{ legend | safe }}</div>
         {% endfor %}
     </div>
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"></script>
+    <script src="https://unpkg.com/maplibre-gl@{{ maplibre_version }}/dist/maplibre-gl.js"></script>
     {% if draw_control %}
     <script src="https://unpkg.com/@mapbox/mapbox-gl-draw@latest/dist/mapbox-gl-draw.js"></script>
     {% endif %}

--- a/tests/test_maplibre_version.py
+++ b/tests/test_maplibre_version.py
@@ -1,0 +1,7 @@
+from maplibreum.core import Map
+
+
+def test_maplibre_version_override():
+    m = Map(maplibre_version="2.4.0")
+    html = m.render()
+    assert "maplibre-gl@2.4.0" in html


### PR DESCRIPTION
## Summary
- allow passing `maplibre_version` to `Map` and inject into template URLs
- document pinning MapLibre GL JS version
- test version override rendering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a8ae0c060c832fa21670920f906e40