### PR TITLE
Add fill extrusion layer helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ geojson = {"type": "FeatureCollection", "features": []}
 source = {"type": "geojson", "data": geojson}
 m.add_heatmap_layer("heat", source)
 
+# Add a 3D fill-extrusion layer
+buildings = {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}}
+m.add_fill_extrusion_layer("buildings", buildings)
+
 # Save the map to an HTML file
 m.save("my_map.html")
 ```

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -367,6 +367,27 @@ class Map:
             layer_definition["filter"] = filter
         self.add_layer(layer_definition, source=source, before=before)
 
+    def add_fill_extrusion_layer(
+        self, name, source, paint=None, layout=None, before=None, filter=None
+    ):
+        """Add a fill-extrusion layer to the map."""
+        if paint is None:
+            paint = {
+                "fill-extrusion-height": 10,
+                "fill-extrusion-color": "#007cbf",
+                "fill-extrusion-opacity": 0.6,
+            }
+        layer_definition = {
+            "id": name,
+            "type": "fill-extrusion",
+            "paint": paint,
+        }
+        if layout:
+            layer_definition["layout"] = layout
+        if filter:
+            layer_definition["filter"] = filter
+        self.add_layer(layer_definition, source=source, before=before)
+
     def add_line_layer(
         self, name, source, paint=None, layout=None, before=None, filter=None
     ):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -62,6 +62,15 @@ def test_shape_layers(map_instance):
     assert types == ["circle", "line", "fill"]
 
 
+def test_fill_extrusion_layer(map_instance):
+    source = {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}}
+    map_instance.add_fill_extrusion_layer("extrusion", source)
+    layer = map_instance.layers[0]["definition"]
+    assert layer["type"] == "fill-extrusion"
+    assert layer["paint"]["fill-extrusion-height"] == 10
+    assert layer["paint"]["fill-extrusion-color"] == "#007cbf"
+
+
 def test_heatmap_layer(map_instance):
     source = {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}}
     map_instance.add_heatmap_layer("heat", source)


### PR DESCRIPTION
## Summary
- add `add_fill_extrusion_layer` to Map with default height, color and opacity
- document 3D fill extrusion usage example in README
- test new fill-extrusion helper for expected paint defaults

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a8ae11a7ac832fba32bc917eb4a622