### PR TITLE
Add pitch and bearing options to Map

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -35,6 +35,8 @@ class Map:
         map_style="basic",
         center=[0, 0],
         zoom=2,
+        pitch=None,
+        bearing=None,
         width="100%",
         height="500px",
         controls=None,
@@ -51,6 +53,8 @@ class Map:
             self.map_style = map_style
         self.center = center
         self.zoom = zoom
+        self.pitch = pitch
+        self.bearing = bearing
         self.width = width
         self.height = height
         self.controls = controls if controls is not None else []
@@ -459,12 +463,21 @@ class Map:
         # The template expects #map { width: ..., height: ... } to be set via custom_css if desired.
         dimension_css = f"#map {{ width: {self.width}; height: {self.height}; }}"
         final_custom_css = dimension_css + "\n" + self.custom_css
+        map_options = {
+            "container": "map",
+            "style": self.map_style,
+        }
+        if self.bounds is None:
+            map_options["center"] = self.center
+            map_options["zoom"] = self.zoom
+        if self.pitch is not None:
+            map_options["pitch"] = self.pitch
+        if self.bearing is not None:
+            map_options["bearing"] = self.bearing
 
         return self.template.render(
             title=self.title,
-            map_style=self.map_style,
-            center=self.center,
-            zoom=self.zoom,
+            map_options=map_options,
             bounds=self.bounds,
             bounds_padding=self.bounds_padding,
             sources=self.sources,

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -60,12 +60,7 @@
     {% endif %}
     <script>
         // Initialize map
-        var map = new maplibregl.Map({
-            container: 'map',
-            style: {{ map_style | tojson }}{% if not bounds %},
-            center: {{ center | tojson }},
-            zoom: {{ zoom }}{% endif %}
-        });
+        var map = new maplibregl.Map({{ map_options | tojson }});
 
 
 // Add controls

--- a/tests/test_pitch_bearing.py
+++ b/tests/test_pitch_bearing.py
@@ -1,0 +1,9 @@
+import pytest
+from maplibreum.core import Map
+
+
+def test_render_includes_pitch_and_bearing():
+    m = Map(pitch=45, bearing=90)
+    html = m.render()
+    assert '"pitch": 45' in html
+    assert '"bearing": 90' in html


### PR DESCRIPTION
## Summary
- allow Map to accept optional pitch and bearing and forward them to template
- simplify template map constructor and render logic via `map_options`
- test rendering for pitch and bearing in generated HTML

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a8ae125498832f89175bcb6024e8b8