### PR TITLE
Add geolocate and attribution controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ geojson = {"type": "FeatureCollection", "features": []}
 source = {"type": "geojson", "data": geojson}
 m.add_heatmap_layer("heat", source)
 
+# Enable built-in controls
+m.add_control("geolocate", "top-right", options={"trackUserLocation": True})
+m.add_control(
+    "attribution", "bottom-right", options={"customAttribution": "My Data"}
+)
+
 # Save the map to an HTML file
 m.save("my_map.html")
 ```

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -95,11 +95,21 @@ class Map:
         self.bounds_padding = padding
 
     def add_control(self, control_type, position="top-right", options=None):
-        """
-        Add a control to the map.
-        control_type: str, one of ['navigation', 'scale', 'fullscreen']
-        position: str, e.g. 'top-right', 'top-left', etc.
-        options: dict, e.g. for scale control { "maxWidth": 80, "unit": "imperial" }
+        """Add a UI control to the map.
+
+        Parameters
+        ----------
+        control_type : str
+            Type of control to add. Supported values are ``'navigation'``,
+            ``'scale'``, ``'fullscreen'``, ``'geolocate'`` and
+            ``'attribution'``.
+        position : str, optional
+            Position on the map (e.g. ``'top-right'`` or ``'bottom-left'``).
+        options : dict, optional
+            Options forwarded to the underlying MapLibre GL control
+            constructor. For example ``{"maxWidth": 80, "unit": "imperial"}``
+            for the scale control or ``{"trackUserLocation": true}`` for the
+            geolocate control.
         """
         if options is None:
             options = {}

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -76,6 +76,10 @@ map.addControl(new maplibregl.NavigationControl(), "{{ ctrl.position }}");
 map.addControl(new maplibregl.ScaleControl({{ ctrl.options | tojson }}), "{{ ctrl.position }}");
 {% elif ctrl.type == "fullscreen" %}
 map.addControl(new maplibregl.FullscreenControl(), "{{ ctrl.position }}");
+{% elif ctrl.type == "geolocate" %}
+map.addControl(new maplibregl.GeolocateControl({{ ctrl.options | tojson }}), "{{ ctrl.position }}");
+{% elif ctrl.type == "attribution" %}
+map.addControl(new maplibregl.AttributionControl({{ ctrl.options | tojson }}), "{{ ctrl.position }}");
 {% endif %}
 {% endfor %}
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -53,6 +53,16 @@ def test_add_layer_control(map_instance):
     ]
 
 
+def test_geolocate_and_attribution_controls(map_instance):
+    map_instance.add_control("geolocate", "top-right")
+    map_instance.add_control(
+        "attribution", "bottom-right", options={"customAttribution": "Test"}
+    )
+    html = map_instance.render()
+    assert "GeolocateControl" in html
+    assert "AttributionControl" in html
+
+
 def test_shape_layers(map_instance):
     source = {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}}
     map_instance.add_circle_layer("circle", source)


### PR DESCRIPTION
## Summary
- allow Map.add_control to document geolocate and attribution control types
- render geolocate and attribution via `map.addControl` in the HTML template
- document and test the new controls

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a8ae1416e8832fb7a99d71b7e000af