### PR TITLE
Add CI workflow for pytest with pip caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            **/pyproject.toml
+            **/setup.cfg
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install pytest
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- run tests on push and pull_request with GitHub Actions
- test against Python 3.8-3.12 and cache pip dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a91d190078832fb670d8c5545571af