### PR TITLE
Use unique map container IDs

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -500,11 +500,13 @@ class Map:
 
     def render(self):
         # Inject custom CSS to adjust the map div if needed
-        # The template expects #map { width: ..., height: ... } to be set via custom_css if desired.
-        dimension_css = f"#map {{ width: {self.width}; height: {self.height}; }}"
+        # The template expects a selector for the map container to set width/height.
+        dimension_css = (
+            f"#{self.map_id} {{ width: {self.width}; height: {self.height}; }}"
+        )
         final_custom_css = dimension_css + "\n" + self.custom_css
         map_options = {
-            "container": "map",
+            "container": self.map_id,
             "style": self.map_style,
         }
         if self.bounds is None:

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -14,7 +14,7 @@
             padding: 0;
         }
 
-        #map {
+        #{{ map_id }} {
             width: 100%;
             height: 500px;
             position: relative;
@@ -49,7 +49,7 @@
     </style>
 </head>
 <body>
-    <div id="map">
+    <div id="{{ map_id }}">
         {% for legend in legends %}
         <div class="maplibreum-legend">{{ legend | safe }}</div>
         {% endfor %}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -19,7 +19,17 @@ def test_map_render_contains_style(map_instance):
     html = map_instance.render()
     assert isinstance(html, str)
     assert map_instance.map_style in html
-    assert '<div id="map"' in html
+    assert f'<div id="{map_instance.map_id}"' in html
+
+
+def test_multiple_maps_have_unique_ids():
+    m1 = Map()
+    m2 = Map()
+    html1 = m1.render()
+    html2 = m2.render()
+    assert m1.map_id != m2.map_id
+    assert f'<div id="{m1.map_id}"' in html1
+    assert f'<div id="{m2.map_id}"' in html2
 
 
 def test_add_tile_layer(map_instance):


### PR DESCRIPTION
## Summary
- Use each map's `map_id` for rendered container CSS and MapLibre options
- Update template to reference `{{ map_id }}` for container and style selectors
- Add test confirming distinct container IDs when rendering multiple maps

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a91d032794832f8722e5f76a8219e1