### PR TITLE
Add video overlay support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,5 +4,5 @@
 - [ ] Measure control to calculate distances and areas
 - [ ] TimeDimension support for time-enabled layers
 - [ ] Search control for geocoding and feature lookup
-- [ ] Video overlay support
+- [x] Video overlay support
 - [ ] Advanced popup class with templating

--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -5,6 +5,7 @@ from .core import (
     Legend,
     Icon,
     ImageOverlay,
+    VideoOverlay,
     Tooltip,
     LatLngPopup,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "Choropleth",
     "Icon",
     "ImageOverlay",
+    "VideoOverlay",
     "Tooltip",
     "LatLngPopup",
 ]

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -1205,6 +1205,82 @@ class ImageOverlay:
         return self
 
 
+class VideoOverlay:
+    """Overlay a georeferenced video on the map."""
+
+    def __init__(
+        self,
+        videos,
+        bounds=None,
+        coordinates=None,
+        opacity=1.0,
+        attribution=None,
+        name=None,
+    ):
+        """Create a VideoOverlay.
+
+        Parameters
+        ----------
+        videos : str or list
+            URL or local path to the video, or a list of URLs for different
+            formats.
+        bounds : list, optional
+            Bounds of the video as ``[west, south, east, north]`` or
+            ``[[west, south], [east, north]]``.
+        coordinates : list, optional
+            Four corner coordinates of the video specified as
+            ``[[west, north], [east, north], [east, south], [west, south]]``.
+            If provided, ``bounds`` is ignored.
+        opacity : float, optional
+            Opacity of the raster layer, defaults to ``1.0``.
+        attribution : str, optional
+            Attribution text for the source.
+        name : str, optional
+            Layer identifier. If omitted, a unique one is generated.
+        """
+
+        if isinstance(videos, str):
+            self.urls = [videos]
+        else:
+            self.urls = list(videos)
+        self.attribution = attribution
+        self.opacity = opacity
+        self.name = name or f"videooverlay_{uuid.uuid4().hex}"
+
+        if coordinates is not None:
+            self.coordinates = coordinates
+        elif bounds is not None:
+            if len(bounds) == 2 and all(len(b) == 2 for b in bounds):
+                west, south = bounds[0]
+                east, north = bounds[1]
+            else:
+                west, south, east, north = bounds
+            self.coordinates = [
+                [west, north],
+                [east, north],
+                [east, south],
+                [west, south],
+            ]
+        else:
+            raise ValueError("Either coordinates or bounds must be provided")
+
+    def add_to(self, map_instance):
+        source = {
+            "type": "video",
+            "urls": self.urls,
+            "coordinates": self.coordinates,
+        }
+        if self.attribution:
+            source["attribution"] = self.attribution
+
+        layer = {"id": self.name, "type": "raster", "source": self.name}
+        if self.opacity is not None:
+            layer["paint"] = {"raster-opacity": self.opacity}
+
+        map_instance.add_layer(layer, source=source)
+        return self
+
+
 class FeatureGroup:
     """Group multiple layers so they can be toggled together."""
 

--- a/tests/test_video_overlay.py
+++ b/tests/test_video_overlay.py
@@ -1,0 +1,28 @@
+import pytest
+from maplibreum.core import Map, VideoOverlay
+
+
+def test_video_overlay_bounds_and_opacity():
+    m = Map()
+    video_url = "https://example.com/video.mp4"
+    bounds = [-1.0, -2.0, 3.0, 4.0]
+    overlay = VideoOverlay(video_url, bounds=bounds, opacity=0.5, attribution="Demo")
+    overlay.add_to(m)
+
+    assert len(m.sources) == 1
+    src_def = m.sources[0]["definition"]
+    assert src_def["type"] == "video"
+    assert src_def["urls"] == [video_url]
+    expected_coords = [
+        [bounds[0], bounds[3]],
+        [bounds[2], bounds[3]],
+        [bounds[2], bounds[1]],
+        [bounds[0], bounds[1]],
+    ]
+    assert src_def["coordinates"] == expected_coords
+    assert src_def["attribution"] == "Demo"
+
+    assert len(m.layers) == 1
+    layer_def = m.layers[0]["definition"]
+    assert layer_def["type"] == "raster"
+    assert layer_def["paint"]["raster-opacity"] == 0.5


### PR DESCRIPTION
## Summary
- add `VideoOverlay` class for georeferenced video overlays
- expose `VideoOverlay` in package exports and test coverage
- mark TODO item for video overlay support as complete

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af170a4e90832f8bc3c1bd7fd23cd3