### PR TITLE
Add terrain, sky, and fog helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ m.add_control(
     "attribution", "bottom-right", options={"customAttribution": "My Data"}
 )
 
+# Enable terrain and atmospheric effects
+m.add_dem_source("terrain", "https://example.com/dem.png")
+m.set_terrain("terrain")
+m.add_sky_layer()
+m.set_fog()
+
 # Save the map to an HTML file
 m.save("my_map.html")
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 - [ ] Search control for geocoding and feature lookup
 - [ ] Optimized marker clustering for large datasets
 - [x] Video overlay support
+- [x] Terrain, sky, and fog helpers
 - [ ] Advanced popup class with templating
 
 - [ ] Floating image overlays similar to Folium's FloatImage plugin

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -83,6 +83,8 @@ class Map:
         self.draw_control = False
         self.draw_control_options = {}
         self.lat_lng_popup = False
+        self.terrain = None
+        self.fog = None
 
 
         template_dir = os.path.join(os.path.dirname(__file__), "templates")
@@ -282,6 +284,31 @@ class Map:
         url = f"{base_url}?{query}"
 
         self.add_tile_layer(url, name=name, attribution=attribution)
+
+    def add_dem_source(self, name, url, tile_size=512, attribution=None):
+        """Add a raster-dem source for terrain rendering."""
+        source = {"type": "raster-dem", "tiles": [url], "tileSize": tile_size}
+        if attribution:
+            source["attribution"] = attribution
+        self.add_source(name, source)
+        return name
+
+    def set_terrain(self, source_name, exaggeration=1.0):
+        """Enable 3D terrain using the given raster-dem source."""
+        self.terrain = {"source": source_name, "exaggeration": exaggeration}
+
+    def add_sky_layer(self, name="sky", paint=None, layout=None, before=None):
+        """Add a sky layer to the map."""
+        if paint is None:
+            paint = {"sky-type": "atmosphere"}
+        layer_definition = {"id": name, "type": "sky", "paint": paint}
+        if layout:
+            layer_definition["layout"] = layout
+        self.add_layer(layer_definition, before=before)
+
+    def set_fog(self, options=None):
+        """Set global fog options for the map."""
+        self.fog = options if options is not None else {}
 
     def add_popup(
         self, html, coordinates=None, layer_id=None, events=None, options=None
@@ -545,6 +572,8 @@ class Map:
             maplibre_version=self.maplibre_version,
             map_id=self.map_id,
             lat_lng_popup=self.lat_lng_popup,
+            terrain=self.terrain,
+            fog=self.fog,
         )
 
     def _repr_html_(self):

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -102,6 +102,13 @@ map.on('load', function() {
     map.addSource("{{ source.name }}", {{ source.definition | tojson | safe }});
     {% endfor %}
 
+    {% if terrain %}
+    map.setTerrain({{ terrain | tojson | safe }});
+    {% endif %}
+    {% if fog is not none %}
+    map.setFog({{ fog | tojson | safe }});
+    {% endif %}
+
     // Add layers
     {% for layer in layers %}
     map.addLayer({{ layer.definition | tojson | safe }}{% if layer.before %}, "{{ layer.before }}"{% endif %});

--- a/tests/test_terrain_sky_fog.py
+++ b/tests/test_terrain_sky_fog.py
@@ -1,0 +1,31 @@
+import pytest
+from maplibreum.core import Map
+
+
+@pytest.fixture
+def map_instance():
+    return Map()
+
+
+def test_terrain(map_instance):
+    map_instance.add_dem_source("terrain", "https://example.com/dem.png")
+    map_instance.set_terrain("terrain", exaggeration=1.2)
+    html = map_instance.render()
+    source = next(s for s in map_instance.sources if s["name"] == "terrain")
+    assert source["definition"]["type"] == "raster-dem"
+    assert "setTerrain" in html
+    assert '"source": "terrain"' in html
+
+
+def test_sky_layer(map_instance):
+    map_instance.add_sky_layer()
+    html = map_instance.render()
+    assert any(l["definition"]["type"] == "sky" for l in map_instance.layers)
+    assert '"type": "sky"' in html
+
+
+def test_fog(map_instance):
+    map_instance.set_fog()
+    html = map_instance.render()
+    assert "setFog" in html
+


### PR DESCRIPTION
## Summary
- add support for raster-dem terrain sources and MapLibre terrain, fog, and sky helpers
- document terrain, sky, and fog usage and update project TODO
- cover terrain, sky, and fog with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af1b537194832f89f1df523c5accec