### PR TITLE
Add expression builder utility and refactor layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ Marker(coordinates=[0, 0]).add_to(cluster)
 LayerControl().add_to(m)
 ```
 
+## Expressions
+
+MapLibre uses array-based expressions for data-driven styling. The
+``maplibreum.expressions`` module provides helpers to construct and
+validate these expressions:
+
+```python
+from maplibreum.expressions import get, interpolate, var
+
+color = interpolate(
+    "linear",
+    var("heatmap-density"),
+    [(0, "blue"), (1, "red")],
+)
+```
+
 ## Example Notebooks
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,5 @@
 - [ ] Advanced popup class with templating
 
 - [ ] Floating image overlays similar to Folium's FloatImage plugin
+- [x] Expression builder and validation utilities
+

--- a/maplibreum/choropleth.py
+++ b/maplibreum/choropleth.py
@@ -1,6 +1,8 @@
 import math
 import uuid  # for generating unique layer/source identifiers
 
+from .expressions import get as expr_get
+
 
 class Choropleth:
     """Simple choropleth renderer for GeoJSON data.
@@ -108,7 +110,7 @@ class Choropleth:
             "type": "fill",
             "source": source_id,
             "paint": {
-                "fill-color": ["get", "fillColor", ["properties"]],
+                "fill-color": expr_get("fillColor", ["properties"]),
                 "fill-opacity": 0.7,
             },
         }

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -7,6 +7,8 @@ import uuid
 from IPython.display import IFrame, display
 from jinja2 import Environment, FileSystemLoader
 
+from .expressions import get as expr_get, interpolate, var
+
 
 # Predefined map styles
 MAP_STYLES = {
@@ -460,23 +462,18 @@ class Map:
             "heatmap-radius": 20,
             "heatmap-intensity": 1,
             "heatmap-opacity": 1,
-            "heatmap-color": [
-                "interpolate",
-                ["linear"],
-                ["heatmap-density"],
-                0,
-                "rgba(0,0,255,0)",
-                0.2,
-                "blue",
-                0.4,
-                "cyan",
-                0.6,
-                "lime",
-                0.8,
-                "yellow",
-                1,
-                "red",
-            ],
+            "heatmap-color": interpolate(
+                "linear",
+                var("heatmap-density"),
+                [
+                    (0, "rgba(0,0,255,0)"),
+                    (0.2, "blue"),
+                    (0.4, "cyan"),
+                    (0.6, "lime"),
+                    (0.8, "yellow"),
+                    (1, "red"),
+                ],
+            ),
         }
         if paint:
             default_paint.update(paint)
@@ -630,7 +627,7 @@ class MarkerCluster:
                 "circle-color": "#51bbd6",
                 "circle-radius": [
                     "step",
-                    ["get", "point_count"],
+                    expr_get("point_count"),
                     20,
                     100,
                     30,
@@ -648,7 +645,7 @@ class MarkerCluster:
             "source": self.source_name,
             "filter": ["has", "point_count"],
             "layout": {
-                "text-field": ["get", "point_count_abbreviated"],
+                "text-field": expr_get("point_count_abbreviated"),
                 "text-font": ["Arial Unicode MS Bold"],
                 "text-size": 12,
             },
@@ -662,7 +659,7 @@ class MarkerCluster:
             "source": self.source_name,
             "filter": ["!", ["has", "point_count"]],
             "paint": {
-                "circle-color": ["coalesce", ["get", "color"], "#007cbf"],
+                "circle-color": ["coalesce", expr_get("color"), "#007cbf"],
                 "circle-radius": 8,
                 "circle-stroke-width": 1,
                 "circle-stroke-color": "#fff",
@@ -824,7 +821,7 @@ class GeoJson:
         map_instance.add_source(source_id, source)
 
         def _get(prop):
-            return ["get", prop, ["properties"]]
+            return expr_get(prop, ["properties"])
 
         geometry_types = [
             f.get("geometry", {}).get("type") for f in features if f.get("geometry")

--- a/maplibreum/expressions.py
+++ b/maplibreum/expressions.py
@@ -1,0 +1,101 @@
+"""Utility functions for building and validating MapLibre expressions.
+
+MapLibre expressions are represented as nested lists following the
+MapLibre GL JS style specification.  This module provides small helper
+functions to create these lists while ensuring they are well formed.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Sequence, Tuple
+
+Expression = List[Any]
+
+
+def validate(expr: Any) -> bool:
+    """Validate that *expr* is a well-formed MapLibre expression.
+
+    Parameters
+    ----------
+    expr : Any
+        Expression to validate.
+
+    Returns
+    -------
+    bool
+        ``True`` if validation succeeds.  A :class:`ValueError` is raised
+        if the expression structure is invalid.
+    """
+    if not isinstance(expr, list):
+        raise ValueError("Expression must be a list")
+    if not expr:
+        raise ValueError("Expression cannot be empty")
+    if not isinstance(expr[0], str):
+        raise ValueError("First element must be an operator string")
+    for arg in expr[1:]:
+        if isinstance(arg, list):
+            validate(arg)
+        elif isinstance(arg, (str, int, float, bool, dict, type(None))):
+            continue
+        else:
+            raise ValueError(f"Unsupported argument type: {type(arg).__name__}")
+    return True
+
+
+def expression(op: str, *args: Any) -> Expression:
+    """Build and validate a raw expression."""
+    expr = [op, *args]
+    validate(expr)
+    return expr
+
+
+def get(property: str, context: Any | None = None) -> Expression:
+    """Return a ``get`` expression for *property* within *context*.
+
+    Parameters
+    ----------
+    property : str
+        Name of the property to read.
+    context : Any, optional
+        Optional context, such as ``["properties"]``.
+    """
+    if context is None:
+        expr = ["get", property]
+    else:
+        expr = ["get", property, context]
+    validate(expr)
+    return expr
+
+
+def var(name: str) -> Expression:
+    """Return an expression referencing a variable or attribute."""
+    expr = [name]
+    validate(expr)
+    return expr
+
+
+def interpolate(
+    method: str | Sequence[Any],
+    input_expr: Any,
+    stops: Iterable[Tuple[Any, Any]],
+) -> Expression:
+    """Return an ``interpolate`` expression.
+
+    Parameters
+    ----------
+    method : str or sequence
+        Interpolation method, e.g. ``"linear"`` or ``["linear"]``.
+    input_expr : Any
+        Input expression that provides the value to interpolate.
+    stops : iterable of (stop, value)
+        Sequence of pairs defining interpolation stops.
+    """
+    if isinstance(method, str):
+        method = [method]
+    expr: Expression = ["interpolate", list(method), input_expr]
+    for stop, value in stops:
+        expr.extend([stop, value])
+    validate(expr)
+    return expr
+
+
+__all__ = ["expression", "get", "var", "interpolate", "validate"]

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,0 +1,22 @@
+import pytest
+
+from maplibreum.expressions import get, interpolate, var, validate
+
+
+def test_get_expression():
+    expr = get("fillColor", ["properties"])
+    assert expr == ["get", "fillColor", ["properties"]]
+    assert validate(expr)
+
+
+def test_interpolate_and_validation():
+    expr = interpolate(
+        "linear",
+        var("heatmap-density"),
+        [(0, "blue"), (1, "red")],
+    )
+    assert expr[0] == "interpolate"
+    assert validate(expr)
+
+    with pytest.raises(ValueError):
+        validate("not an expression")


### PR DESCRIPTION
## Summary
- add `expressions` module for building and validating MapLibre expressions
- refactor layer helpers to use expression utilities
- document expressions module and add regression tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af1b58d558832fb5aee4df6214d251