### PR TITLE
Add style loading support with load_style method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ m.add_control(
     "attribution", "bottom-right", options={"customAttribution": "My Data"}
 )
 
+# Load an external style
+m.load_style("https://demotiles.maplibre.org/style.json")
+
 # Save the map to an HTML file
 m.save("my_map.html")
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 - [ ] Search control for geocoding and feature lookup
 - [ ] Optimized marker clustering for large datasets
 - [x] Video overlay support
+- [x] External style loading from URL or JSON
 - [ ] Advanced popup class with templating
 
 - [ ] Floating image overlays similar to Folium's FloatImage plugin

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -60,7 +60,9 @@
     {% endif %}
     <script>
         // Initialize map
-        var map = new maplibregl.Map({{ map_options | tojson }});
+        var mapOptions = {{ map_options | tojson }};
+        mapOptions.style = {{ style | tojson | safe }};
+        var map = new maplibregl.Map(mapOptions);
 
 
 // Add controls

--- a/tests/test_style_loading.py
+++ b/tests/test_style_loading.py
@@ -1,0 +1,32 @@
+from maplibreum import Map
+
+
+def test_load_style_url():
+    m = Map()
+    m.load_style("https://demotiles.maplibre.org/style.json")
+    source = {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}}
+    m.add_circle_layer("points", source)
+    html = m.render()
+    assert "https://demotiles.maplibre.org/style.json" in html
+    assert "\"points\"" in html
+
+
+def test_load_style_object():
+    style = {
+        "version": 8,
+        "sources": {},
+        "layers": [
+            {
+                "id": "background",
+                "type": "background",
+                "paint": {"background-color": "#fff"},
+            }
+        ],
+    }
+    m = Map()
+    m.load_style(style)
+    source = {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}}
+    m.add_fill_layer("fills", source)
+    html = m.render()
+    assert "background-color" in html
+    assert "\"fills\"" in html


### PR DESCRIPTION
## Summary
- add `Map.load_style` to accept style URLs or JSON definitions
- initialize templates using provided style objects
- document style loading capability and test it

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af1b57b274832f8bfd1a2e0b8a5ac9