### PR TITLE
Add draggable markers with drag event updates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,5 +7,6 @@
 - [ ] Optimized marker clustering for large datasets
 - [x] Video overlay support
 - [ ] Advanced popup class with templating
+- [x] Draggable markers with coordinate updates
 
 - [ ] Floating image overlays similar to Folium's FloatImage plugin

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -77,6 +77,16 @@
     "# In a Jupyter notebook, just display:\n",
     "m"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6808ee14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_marker(draggable=True, popup='Drag me!')"
+   ]
   }
  ],
  "metadata": {

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -29,6 +29,7 @@ class Tooltip:
 
 class Map:
     _drawn_data = {}
+    _marker_registry = {}
     def __init__(
         self,
         title="MapLibreum Map",
@@ -72,6 +73,7 @@ class Map:
         self.overlays = []
         self.popups = popups if popups is not None else []
         self.tooltips = tooltips if tooltips is not None else []
+        self.markers = []
         self.legends = []
         self.extra_js = extra_js
         self.custom_css = custom_css
@@ -331,6 +333,7 @@ class Map:
         cluster=None,
         icon=None,
         tooltip=None,
+        draggable=False,
     ):
 
         """Add a marker to the map.
@@ -351,6 +354,8 @@ class Map:
             Custom icon for the marker. If provided, ``color`` is ignored.
         tooltip : str or Tooltip, optional
             Text for a tooltip bound to the marker.
+        draggable : bool, optional
+            Whether the marker should be draggable.
         """
         if coordinates is None:
             coordinates = self.center
@@ -361,6 +366,7 @@ class Map:
             color=color,
             icon=icon,
             tooltip=tooltip,
+            draggable=draggable,
         )
         if cluster:
             cluster.add_marker(marker)
@@ -536,6 +542,7 @@ class Map:
             layer_control=self.layer_control,
             popups=self.popups,
             tooltips=self.tooltips,
+            markers=self.markers,
             legends=[legend.render() for legend in self.legends],
             cluster_layers=self.cluster_layers,
             extra_js=self.extra_js,
@@ -575,6 +582,16 @@ class Map:
     @classmethod
     def _store_drawn_features(cls, map_id, geojson_str):
         cls._drawn_data[map_id] = json.loads(geojson_str)
+
+    @classmethod
+    def _register_marker(cls, map_id, marker):
+        cls._marker_registry.setdefault(map_id, {})[marker.id] = marker
+
+    @classmethod
+    def _update_marker_coords(cls, map_id, marker_id, lng, lat):
+        marker = cls._marker_registry.get(map_id, {}).get(marker_id)
+        if marker:
+            marker.coordinates = [lng, lat]
 
     @property
     def drawn_features(self):
@@ -704,16 +721,36 @@ class Marker:
         color="#007cbf",
         icon=None,
         tooltip=None,
+        draggable=False,
     ):
         self.coordinates = coordinates
         self.popup = popup
         self.color = color
         self.icon = icon
         self.tooltip = tooltip
+        self.draggable = draggable
+        self.id = None
 
     def add_to(self, map_instance):
         if isinstance(map_instance, MarkerCluster):
+            if self.draggable:
+                raise ValueError("Draggable markers cannot be added to a cluster")
             map_instance.add_marker(self)
+            return self
+
+        if self.draggable:
+            self.id = f"marker_{uuid.uuid4().hex}"
+            map_instance.markers.append(
+                {
+                    "id": self.id,
+                    "coordinates": self.coordinates,
+                    "color": self.color,
+                    "popup": self.popup,
+                    "tooltip": self.tooltip,
+                    "draggable": True,
+                }
+            )
+            Map._register_marker(map_instance.map_id, self)
             return self
 
         layer_id = f"marker_{uuid.uuid4().hex}"

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -196,6 +196,37 @@ map.on('load', function() {
     map.getContainer().appendChild(layerControl);
     {% endif %}
 
+    // Markers
+    {% for marker in markers %}
+    var marker_{{ marker.id }} = new maplibregl.Marker({{ {'color': marker.color, 'draggable': marker.draggable} | tojson | safe }})
+        .setLngLat({{ marker.coordinates | tojson }})
+        .addTo(map);
+    {% if marker.popup %}
+    marker_{{ marker.id }}.setPopup(new maplibregl.Popup().setHTML(`{{ marker.popup }}`));
+    {% endif %}
+    {% if marker.tooltip %}
+    var tooltip_{{ marker.id }} = new maplibregl.Popup({closeButton: false});
+    marker_{{ marker.id }}.getElement().addEventListener('mouseenter', function() {
+        tooltip_{{ marker.id }}
+            .setLngLat(marker_{{ marker.id }}.getLngLat())
+            .setHTML(`{{ marker.tooltip }}`)
+            .addTo(map);
+    });
+    marker_{{ marker.id }}.getElement().addEventListener('mouseleave', function() {
+        tooltip_{{ marker.id }}.remove();
+    });
+    {% endif %}
+    {% if marker.draggable %}
+    marker_{{ marker.id }}.on('dragend', function() {
+        var lngLat = marker_{{ marker.id }}.getLngLat();
+        if (window.Jupyter && Jupyter.notebook && Jupyter.notebook.kernel) {
+            var cmd = "from maplibreum.core import Map; Map._update_marker_coords('" + "{{ map_id }}" + "', '" + "{{ marker.id }}" + "', " + lngLat.lng + ", " + lngLat.lat + ")";
+            Jupyter.notebook.kernel.execute(cmd);
+        }
+    });
+    {% endif %}
+    {% endfor %}
+
     {% for cl in cluster_layers %}
     map.on('click', '{{ cl.cluster_layer }}', function(e) {
         var features = map.queryRenderedFeatures(e.point, { layers: ['{{ cl.cluster_layer }}'] });

--- a/tests/test_marker_draggable.py
+++ b/tests/test_marker_draggable.py
@@ -1,0 +1,20 @@
+from maplibreum.core import Map, Marker
+
+
+def test_draggable_marker_updates_coordinates_and_js():
+    m = Map()
+    marker = Marker(coordinates=[0, 0], popup="Drag me", draggable=True)
+    marker.add_to(m)
+
+    # Draggable markers are stored separately from layers
+    assert len(m.layers) == 0
+    assert len(m.markers) == 1
+    assert m.markers[0]["draggable"] is True
+    assert marker.id == m.markers[0]["id"]
+
+    html = m.render()
+    assert '"draggable": true' in html
+
+    # Simulate drag event
+    Map._update_marker_coords(m.map_id, marker.id, 10, 20)
+    assert marker.coordinates == [10, 20]


### PR DESCRIPTION
## Summary
- allow markers to be draggable and track positions in Python
- handle drag events in template to update marker coordinates
- document draggable markers in examples and TODO

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af1b55ea84832faa1e0f07410c8cbc