### PR TITLE
Add event callbacks and Jupyter integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ geojson = {"type": "FeatureCollection", "features": []}
 source = {"type": "geojson", "data": geojson}
 m.add_heatmap_layer("heat", source)
 
+# Register event callbacks (Jupyter notebooks)
+def handle_click(evt):
+    print("Clicked at", evt["lngLat"])
+m.on_click(handle_click)
+
 # Enable built-in controls
 m.add_control("geolocate", "top-right", options={"trackUserLocation": True})
 m.add_control(

--- a/TODO.md
+++ b/TODO.md
@@ -7,5 +7,5 @@
 - [ ] Optimized marker clustering for large datasets
 - [x] Video overlay support
 - [ ] Advanced popup class with templating
-
 - [ ] Floating image overlays similar to Folium's FloatImage plugin
+- [x] Event callbacks for map interactions

--- a/examples/event_handling.ipynb
+++ b/examples/event_handling.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Event handling\n",
+    "Click or move the map to trigger callbacks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from maplibreum import Map\n",
+    "\n",
+    "def handle_click(data):\n",
+    "    print('Clicked at', data['lngLat'])\n",
+    "\n",
+    "def handle_move(data):\n",
+    "    print('Map center', data['center'])\n",
+    "\n",
+    "m = Map()\n",
+    "m.on_click(handle_click)\n",
+    "m.on_move(handle_move)\n",
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -29,6 +29,7 @@ class Tooltip:
 
 class Map:
     _drawn_data = {}
+    _event_callbacks = {}
     def __init__(
         self,
         title="MapLibreum Map",
@@ -83,6 +84,7 @@ class Map:
         self.draw_control = False
         self.draw_control_options = {}
         self.lat_lng_popup = False
+        self.events = []
 
 
         template_dir = os.path.join(os.path.dirname(__file__), "templates")
@@ -323,6 +325,20 @@ class Map:
         """Enable a popup showing latitude and longitude on click."""
         self.lat_lng_popup = True
 
+    def on(self, event, callback):
+        """Register a callback for a given map event."""
+        if event not in self.events:
+            self.events.append(event)
+        self._event_callbacks.setdefault(self.map_id, {})[event] = callback
+
+    def on_click(self, callback):
+        """Convenience method for click events."""
+        self.on("click", callback)
+
+    def on_move(self, callback):
+        """Convenience method for move events."""
+        self.on("move", callback)
+
     def add_marker(
         self,
         coordinates=None,
@@ -545,6 +561,7 @@ class Map:
             maplibre_version=self.maplibre_version,
             map_id=self.map_id,
             lat_lng_popup=self.lat_lng_popup,
+            events=self.events,
         )
 
     def _repr_html_(self):
@@ -575,6 +592,13 @@ class Map:
     @classmethod
     def _store_drawn_features(cls, map_id, geojson_str):
         cls._drawn_data[map_id] = json.loads(geojson_str)
+
+    @classmethod
+    def _handle_event(cls, map_id, event, data_json):
+        callback = cls._event_callbacks.get(map_id, {}).get(event)
+        if callback:
+            data = json.loads(data_json)
+            callback(data)
 
     @property
     def drawn_features(self):

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -214,6 +214,20 @@ map.on('load', function() {
     {% endfor %}
 });
 
+    {% for evt in events %}
+    map.on('{{ evt }}', function(e) {
+        var data = {};
+        if (e.lngLat) { data.lngLat = e.lngLat; }
+        data.center = map.getCenter();
+        data.zoom = map.getZoom();
+        if (window.Jupyter && Jupyter.notebook && Jupyter.notebook.kernel) {
+            var cmd = "from maplibreum.core import Map; Map._handle_event('" + "{{ map_id }}" + "', '" + "{{ evt }}" + "', '" + JSON.stringify(data).replace(/'/g, "\\'") + "')";
+            Jupyter.notebook.kernel.execute(cmd);
+        }
+        
+    });
+    {% endfor %}
+
     {% if lat_lng_popup %}
     map.on('click', function(e) {
         new maplibregl.Popup()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,31 @@
+import json
+
+from maplibreum import Map
+
+
+def test_on_click_event_registration():
+    m = Map()
+    received = {}
+
+    def cb(data):
+        received["data"] = data
+
+    m.on_click(cb)
+    html = m.render()
+    assert "map.on('click'" in html
+    Map._handle_event(m.map_id, "click", json.dumps({"lngLat": {"lng": 1, "lat": 2}}))
+    assert received["data"]["lngLat"]["lng"] == 1
+
+
+def test_on_move_event_registration():
+    m = Map()
+    received = {}
+
+    def cb(data):
+        received.update(data)
+
+    m.on_move(cb)
+    html = m.render()
+    assert "map.on('move'" in html
+    Map._handle_event(m.map_id, "move", json.dumps({"center": {"lng": 4, "lat": 5}}))
+    assert received["center"]["lng"] == 4


### PR DESCRIPTION
## Summary
- allow `Map` instances to register event callbacks with `on`, `on_click`, and `on_move`
- wire template to forward map events from JavaScript back to Python in Jupyter
- document and test event handling with a new example notebook

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af1b5470a0832f871bdc264495069d