### PR TITLE
Add dynamic layer property update API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ m.add_control(
     "attribution", "bottom-right", options={"customAttribution": "My Data"}
 )
 
+# Update layer style or layout after creation
+m.set_paint_property("heat", "heatmap-radius", 40)
+m.set_layout_property("heat", "visibility", "none")
+
 # Save the map to an HTML file
 m.save("my_map.html")
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -8,4 +8,6 @@
 - [x] Video overlay support
 - [ ] Advanced popup class with templating
 
+- [x] Dynamic paint and layout property updates
+
 - [ ] Floating image overlays similar to Folium's FloatImage plugin

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -180,6 +180,48 @@ class Map:
 
         return layer_id
 
+    def set_paint_property(self, layer_id, property_name, value):
+        """Update the paint property of a layer and sync to the front-end."""
+        for layer in self.layers:
+            if layer["id"] == layer_id:
+                paint = layer["definition"].setdefault("paint", {})
+                paint[property_name] = value
+                break
+
+        try:
+            from IPython.display import Javascript, display
+
+            js_value = json.dumps(value)
+            display(
+                Javascript(
+                    f"setPaintProperty('{self.map_id}', '{layer_id}', "
+                    f"'{property_name}', {js_value});"
+                )
+            )
+        except Exception:
+            pass
+
+    def set_layout_property(self, layer_id, property_name, value):
+        """Update the layout property of a layer and sync to the front-end."""
+        for layer in self.layers:
+            if layer["id"] == layer_id:
+                layout = layer["definition"].setdefault("layout", {})
+                layout[property_name] = value
+                break
+
+        try:
+            from IPython.display import Javascript, display
+
+            js_value = json.dumps(value)
+            display(
+                Javascript(
+                    f"setLayoutProperty('{self.map_id}', '{layer_id}', "
+                    f"'{property_name}', {js_value});"
+                )
+            )
+        except Exception:
+            pass
+
     def add_tile_layer(self, url, name=None, attribution=None, subdomains=None):
         """Add a raster tile layer to the map.
 

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -62,6 +62,23 @@
         // Initialize map
         var map = new maplibregl.Map({{ map_options | tojson }});
 
+        window.maplibreum_maps = window.maplibreum_maps || {};
+        window.maplibreum_maps["{{ map_id }}"] = map;
+
+        function setPaintProperty(mapId, layerId, property, value) {
+            var m = window.maplibreum_maps[mapId];
+            if (m) {
+                m.setPaintProperty(layerId, property, value);
+            }
+        }
+
+        function setLayoutProperty(mapId, layerId, property, value) {
+            var m = window.maplibreum_maps[mapId];
+            if (m) {
+                m.setLayoutProperty(layerId, property, value);
+            }
+        }
+
 
 // Add controls
 {% for ctrl in controls %}

--- a/tests/test_property_updates.py
+++ b/tests/test_property_updates.py
@@ -1,0 +1,33 @@
+import pytest
+from maplibreum.core import Map
+
+
+def test_set_paint_property_after_render():
+    m = Map()
+    source = {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}}
+    layer = {"id": "fill", "type": "fill", "paint": {"fill-color": "red"}}
+    m.add_layer(layer, source=source)
+    m.render()
+    m.set_paint_property("fill", "fill-color", "blue")
+    assert m.layers[0]["definition"]["paint"]["fill-color"] == "blue"
+    html = m.render()
+    assert "fill-color\": \"blue\"" in html
+
+
+def test_set_layout_property_after_render():
+    m = Map()
+    source = {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}}
+    layer = {"id": "symbol", "type": "symbol", "layout": {"icon-image": "marker-15"}}
+    m.add_layer(layer, source=source)
+    m.render()
+    m.set_layout_property("symbol", "visibility", "none")
+    assert m.layers[0]["definition"]["layout"]["visibility"] == "none"
+    html = m.render()
+    assert "visibility\": \"none\"" in html
+
+
+def test_template_includes_update_functions():
+    m = Map()
+    html = m.render()
+    assert "function setPaintProperty" in html
+    assert "function setLayoutProperty" in html


### PR DESCRIPTION
## Summary
- allow updating layer paint and layout properties after map creation
- expose `setPaintProperty` and `setLayoutProperty` functions in generated HTML
- document new API and add regression tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af1b532640832f9f4bda1baacbcae0