### PR TITLE
docs: add todo for auto-bound popups

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,3 +6,4 @@
 - [ ] Search control for geocoding and feature lookup
 - [x] Video overlay support
 - [ ] Advanced popup class with templating
+- [ ] Auto-bind popups and tooltips to GeoJSON properties


### PR DESCRIPTION
## Summary
- note auto-bound popups and tooltips in TODO list

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'maplibreum')*


------
https://chatgpt.com/codex/tasks/task_b_68af1a64326c832fafd8eb622d734593