### PR TITLE
Add image and canvas source helpers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,29 @@
 - [ ] Search control for geocoding and feature lookup
 - [ ] Optimized marker clustering for large datasets
 - [x] Video overlay support
+- [x] Image and canvas source helpers
 - [ ] Advanced popup class with templating
 
 - [ ] Floating image overlays similar to Folium's FloatImage plugin
+
+## Usage Examples
+
+```python
+from maplibreum.core import Map
+
+m = Map()
+m.add_image_source(
+    "overlay",
+    "https://example.com/overlay.png",
+    [[-1, 1], [1, 1], [1, -1], [-1, -1]],
+)
+m.add_layer({"id": "image-layer", "type": "raster"}, source="overlay")
+
+m.add_canvas_source(
+    "canvas",
+    "myCanvas",
+    [[-1, 1], [1, 1], [1, -1], [-1, -1]],
+    animate=True,
+)
+m.add_layer({"id": "canvas-layer", "type": "raster"}, source="canvas")
+```

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -67,6 +67,7 @@ class Map:
         self.height = height
         self.controls = controls if controls is not None else []
         self.sources = []
+        self.canvas_sources = []
         self.layers = layers if layers is not None else []
         self.tile_layers = []
         self.overlays = []
@@ -153,6 +154,55 @@ class Map:
         definition: dict, the source definition
         """
         self.sources.append({"name": name, "definition": definition})
+
+    def add_image_source(self, name, url, coordinates, **kwargs):
+        """Add an image source to the map.
+
+        Parameters
+        ----------
+        name : str
+            Name of the source.
+        url : str
+            URL of the image.
+        coordinates : list
+            Four corner coordinates of the image specified as
+            ``[[west, north], [east, north], [east, south], [west, south]]``.
+        **kwargs : dict, optional
+            Additional properties such as ``attribution``.
+        """
+
+        source = {"type": "image", "url": url, "coordinates": coordinates}
+        if kwargs:
+            source.update(kwargs)
+        self.add_source(name, source)
+        return name
+
+    def add_canvas_source(self, name, canvas_id, coordinates, **kwargs):
+        """Add a canvas source to the map.
+
+        Parameters
+        ----------
+        name : str
+            Name of the source.
+        canvas_id : str
+            ID of the canvas element to use.
+        coordinates : list
+            Four corner coordinates of the canvas specified as
+            ``[[west, north], [east, north], [east, south], [west, south]]``.
+        **kwargs : dict, optional
+            Additional properties for the source (e.g. ``animate=True``).
+        """
+
+        source = {
+            "type": "canvas",
+            "canvas": canvas_id,
+            "coordinates": coordinates,
+        }
+        if kwargs:
+            source.update(kwargs)
+        self.add_source(name, source)
+        self.canvas_sources.append(canvas_id)
+        return name
 
     def add_layer(self, layer_definition, source=None, before=None):
         """
@@ -529,6 +579,7 @@ class Map:
             bounds=self.bounds,
             bounds_padding=self.bounds_padding,
             sources=self.sources,
+            canvas_sources=self.canvas_sources,
             controls=self.controls,
             layers=self.layers,
             tile_layers=self.tile_layers,

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -54,6 +54,9 @@
         <div class="maplibreum-legend">{{ legend | safe }}</div>
         {% endfor %}
     </div>
+    {% for cid in canvas_sources %}
+    <canvas id="{{ cid }}" style="display:none;"></canvas>
+    {% endfor %}
     <script src="https://unpkg.com/maplibre-gl@{{ maplibre_version }}/dist/maplibre-gl.js"></script>
     {% if draw_control %}
     <script src="https://unpkg.com/@mapbox/mapbox-gl-draw@latest/dist/mapbox-gl-draw.js"></script>

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,34 @@
+import pytest
+from maplibreum.core import Map
+
+
+def test_add_image_source():
+    m = Map()
+    coords = [[-1.0, 1.0], [1.0, 1.0], [1.0, -1.0], [-1.0, -1.0]]
+    m.add_image_source("imgsrc", "https://example.com/image.png", coords, attribution="Demo")
+    m.add_layer({"id": "img-layer", "type": "raster"}, source="imgsrc")
+
+    assert any(src["name"] == "imgsrc" for src in m.sources)
+    src_def = next(src["definition"] for src in m.sources if src["name"] == "imgsrc")
+    assert src_def["type"] == "image"
+    assert src_def["url"] == "https://example.com/image.png"
+    assert src_def["coordinates"] == coords
+    assert src_def["attribution"] == "Demo"
+    html = m.render()
+    assert 'map.addSource("imgsrc"' in html
+
+
+def test_add_canvas_source():
+    m = Map()
+    coords = [[0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]]
+    m.add_canvas_source("cnvsrc", "mycanvas", coords, animate=True)
+    m.add_layer({"id": "cnv-layer", "type": "raster"}, source="cnvsrc")
+
+    src_def = next(src["definition"] for src in m.sources if src["name"] == "cnvsrc")
+    assert src_def["type"] == "canvas"
+    assert src_def["canvas"] == "mycanvas"
+    assert src_def["coordinates"] == coords
+    assert src_def["animate"] is True
+    html = m.render()
+    assert 'map.addSource("cnvsrc"' in html
+    assert '<canvas id="mycanvas"' in html


### PR DESCRIPTION
## Summary
- add Map.add_image_source and Map.add_canvas_source helpers
- render canvas sources as hidden elements and inject sources into map
- document usage in TODO and cover sources with unit tests
- align canvas source API with image source helper by accepting keyword options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af1b519a78832fba424095a30c8c07