### PR TITLE
This commit adds a new `FloatImage` plugin, similar to Folium's `Floa…

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -91,6 +91,7 @@ class Map:
         self.events = []
         self.terrain = None
         self.fog = None
+        self.float_images = []
 
 
         template_dir = os.path.join(os.path.dirname(__file__), "templates")
@@ -595,6 +596,7 @@ class Map:
             events=self.events,
             terrain=self.terrain,
             fog=self.fog,
+            float_images=self.float_images,
         )
 
     def _repr_html_(self):
@@ -632,6 +634,8 @@ class Map:
         if callback:
             data = json.loads(data_json)
             callback(data)
+
+    @classmethod
     def _register_marker(cls, map_id, marker):
         cls._marker_registry.setdefault(map_id, {})[marker.id] = marker
 
@@ -1287,6 +1291,20 @@ class ImageOverlay:
             layer["paint"] = {"raster-opacity": self.opacity}
 
         map_instance.add_layer(layer, source=source)
+        return self
+
+
+class FloatImage:
+    """Add a floating image to the map."""
+
+    def __init__(self, image_url, bottom=None, left=None, width=None):
+        self.image_url = image_url
+        self.bottom = bottom
+        self.left = left
+        self.width = width
+
+    def add_to(self, map_instance):
+        map_instance.float_images.append(self)
         return self
 
 

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -50,6 +50,9 @@
 </head>
 <body>
     <div id="map">
+        {% for image in float_images %}
+        <img src="{{ image.image_url }}" style="position: absolute; bottom: {{ image.bottom }}px; left: {{ image.left }}px; width: {{ image.width }}px; z-index: 999;">
+        {% endfor %}
         {% for legend in legends %}
         <div class="maplibreum-legend">{{ legend | safe }}</div>
         {% endfor %}

--- a/tests/test_float_image.py
+++ b/tests/test_float_image.py
@@ -1,0 +1,17 @@
+import pytest
+from maplibreum.core import Map, FloatImage
+
+def test_float_image():
+    m = Map()
+    image_url = "https://example.com/image.png"
+    float_image = FloatImage(image_url, bottom=10, left=10, width=100)
+    float_image.add_to(m)
+
+    assert len(m.float_images) == 1
+    assert m.float_images[0] == float_image
+
+    html = m.render()
+    assert image_url in html
+    assert "bottom: 10px" in html
+    assert "left: 10px" in html
+    assert "width: 100px" in html


### PR DESCRIPTION
…tImage` plugin.

The `FloatImage` class allows adding a floating image to the map. The image can be positioned using `bottom`, `left`, and `width` parameters.

A new test file `tests/test_float_image.py` has been added to test the new functionality.

Also, a regression in draggable markers has been fixed by adding the `@classmethod` decorator to the `_register_marker` and `_update_marker_coords` methods in the `Map` class.