### PR TITLE
Add camera camera animation queue and PNG export

### DIFF
--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -261,6 +261,15 @@ map.on('load', function() {
         map.getCanvas().style.cursor = '';
     });
     {% endfor %}
+
+    // Queued camera actions
+    {% for action in camera_actions %}
+    {% if action.method == 'panTo' %}
+    map.panTo({{ action.center | tojson }}, {{ action.options | tojson }});
+    {% else %}
+    map.{{ action.method }}({{ action.options | tojson }});
+    {% endif %}
+    {% endfor %}
 });
 
     {% for evt in events %}

--- a/tests/test_camera_actions.py
+++ b/tests/test_camera_actions.py
@@ -1,0 +1,32 @@
+import subprocess
+
+from maplibreum.core import Map
+
+
+def test_camera_actions_serialization():
+    m = Map()
+    m.fly_to(center=[10, 20], zoom=5)
+    m.ease_to(center=[0, 0], zoom=2)
+    m.pan_to([1, 2], duration=1000)
+    html = m.render()
+    assert 'map.flyTo({"center": [10, 20], "zoom": 5});' in html
+    assert 'map.easeTo({"center": [0, 0], "zoom": 2});' in html
+    assert 'map.panTo([1, 2], {"duration": 1000});' in html
+
+
+def test_export_png_invokes_cli(monkeypatch, tmp_path):
+    m = Map()
+    calls = {}
+
+    def fake_run(cmd, check):
+        calls["cmd"] = cmd
+        calls["check"] = check
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    output = tmp_path / "map.png"
+    m.export_png(str(output), width=800, height=600)
+
+    assert calls["cmd"][0] == "npx"
+    assert "@maplibre/maplibre-gl-export" in calls["cmd"]
+    assert "--output" in calls["cmd"]
+    assert str(output) in calls["cmd"]


### PR DESCRIPTION
## Summary
- queue camera animations on `Map` via `fly_to`, `ease_to`, and `pan_to`
- execute queued camera actions on template load
- add `Map.export_png()` using `@maplibre/maplibre-gl-export`
- test camera serialization and export invocation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c191d7d814832fa3cf412ceb784fbc