### PR TITLE
Add TimeDimension playback support

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -11,6 +11,7 @@ from .core import (
 )
 from .markers import Icon, DivIcon, BeautifyIcon
 from .choropleth import Choropleth
+from .timedimension import TimeDimension
 
 __all__ = [
     "Map",
@@ -26,6 +27,7 @@ __all__ = [
     "VideoOverlay",
     "Tooltip",
     "LatLngPopup",
+    "TimeDimension",
 ]
 
 

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -111,6 +111,8 @@ class Map:
         self.fog = None
         self.float_images = []
         self.camera_actions = []
+        self.time_dimension_data = None
+        self.time_dimension_options = {}
 
 
         template_dir = os.path.join(os.path.dirname(__file__), "templates")
@@ -484,6 +486,22 @@ class Map:
             layer_definition["filter"] = filter
         self.add_layer(layer_definition, source=source, before=before)
 
+    def add_time_dimension(self, data, options=None):
+        """Store timestamped GeoJSON data for simple animation playback.
+
+        Parameters
+        ----------
+        data : dict
+            GeoJSON ``FeatureCollection`` whose features include a ``time``
+            property.
+        options : dict, optional
+            Configuration dictionary. Supports ``interval`` in milliseconds
+            for playback speed.
+        """
+
+        self.time_dimension_data = data
+        self.time_dimension_options = options or {}
+
     def add_fill_layer(
         self, name, source, paint=None, layout=None, before=None, filter=None
     ):
@@ -653,6 +671,9 @@ class Map:
             fog=self.fog,
             float_images=self.float_images,
             camera_actions=self.camera_actions,
+            time_dimension=self.time_dimension_data is not None,
+            time_dimension_data=self.time_dimension_data,
+            time_dimension_options=self.time_dimension_options,
         )
 
     def _repr_html_(self):

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -11,6 +11,9 @@
     {% if include_minimap %}
     <link href="https://unpkg.com/maplibregl-minimap/dist/minimap-control.css" rel="stylesheet" />
     {% endif %}
+    {% if time_dimension %}
+    <link href="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.0/dist/leaflet.timedimension.control.min.css" rel="stylesheet" />
+    {% endif %}
     <style>
         body {
             margin: 0;
@@ -66,6 +69,9 @@
     {% endif %}
     {% if draw_control %}
     <script src="https://unpkg.com/@mapbox/mapbox-gl-draw@latest/dist/mapbox-gl-draw.js"></script>
+    {% endif %}
+    {% if time_dimension %}
+    <script src="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.0/dist/leaflet.timedimension.min.js"></script>
     {% endif %}
     <script>
         // Initialize map
@@ -270,6 +276,26 @@ map.on('load', function() {
         map.getCanvas().style.cursor = '';
     });
     {% endfor %}
+
+    {% if time_dimension %}
+    var tdData = {{ time_dimension_data | tojson | safe }};
+    map.addSource('timedimension', {type: 'geojson', data: tdData});
+    map.addLayer({
+        id: 'timedimension',
+        type: 'circle',
+        source: 'timedimension',
+        paint: { 'circle-radius': 5, 'circle-color': '#ff0000' }
+    });
+    var tdTimes = tdData.features.map(function(f){ return f.properties.time; }).sort();
+    var tdIndex = 0;
+    function tdStep(){
+        var t = tdTimes[tdIndex];
+        map.setFilter('timedimension', ['==', ['get','time'], t]);
+        tdIndex = (tdIndex + 1) % tdTimes.length;
+    }
+    tdStep();
+    setInterval(tdStep, {{ time_dimension_options.interval | default(1000) }});
+    {% endif %}
 
     // Queued camera actions
     {% for action in camera_actions %}

--- a/maplibreum/timedimension.py
+++ b/maplibreum/timedimension.py
@@ -1,0 +1,25 @@
+import uuid
+
+
+class TimeDimension:
+    """Wrapper for timestamped GeoJSON data enabling simple playback.
+
+    Parameters
+    ----------
+    data: dict
+        GeoJSON ``FeatureCollection`` with features carrying a ``time``
+        property.
+    options: dict, optional
+        Additional options for playback, such as ``interval`` in
+        milliseconds.
+    """
+
+    def __init__(self, data, options=None):
+        self.data = data
+        self.options = options or {}
+        self.name = f"timedimension_{uuid.uuid4().hex}"
+
+    def add_to(self, map_instance):
+        """Add this time dimension data to a map instance."""
+        map_instance.add_time_dimension(self.data, self.options)
+        return self

--- a/tests/test_time_dimension.py
+++ b/tests/test_time_dimension.py
@@ -1,0 +1,33 @@
+import pytest
+from maplibreum.core import Map
+
+
+def test_time_dimension_rendering():
+    data = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [0, 0]},
+                "properties": {"time": "2020-01-01T00:00:00Z"},
+            },
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [1, 1]},
+                "properties": {"time": "2020-01-01T01:00:00Z"},
+            },
+        ],
+    }
+
+    m = Map()
+    m.add_time_dimension(data, {"interval": 500})
+    html = m.render()
+    assert "leaflet.timedimension.min.js" in html
+    assert "2020-01-01T00:00:00Z" in html
+    assert "setInterval(tdStep" in html
+
+
+def test_time_dimension_not_included():
+    m = Map()
+    html = m.render()
+    assert "leaflet.timedimension.min.js" not in html


### PR DESCRIPTION
## Summary
- add TimeDimension wrapper for timestamped GeoJSON playback
- inject TimeDimension assets and playback logic into map template
- provide Map.add_time_dimension helper with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c19d88b270832fa3f72a40f20819d7