### PR TITLE
Add GeoJSON popups and tooltips

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -7,6 +7,8 @@ from .core import (
     ImageOverlay,
     VideoOverlay,
     Tooltip,
+    GeoJsonPopup,
+    GeoJsonTooltip,
     LatLngPopup,
 )
 from .markers import Icon, DivIcon, BeautifyIcon
@@ -26,6 +28,8 @@ __all__ = [
     "ImageOverlay",
     "VideoOverlay",
     "Tooltip",
+    "GeoJsonPopup",
+    "GeoJsonTooltip",
     "LatLngPopup",
     "TimeDimension",
 ]

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -133,7 +133,10 @@ map.on('load', function() {
 
     // Popups
     {% for popup in popups %}
-    var popup_{{ loop.index }} = new maplibregl.Popup({{ popup.options | tojson }}).setHTML(`{{ popup.html }}`);
+    var popup_{{ loop.index }} = new maplibregl.Popup({{ popup.options | tojson }});
+    {% if popup.html %}
+    popup_{{ loop.index }}.setHTML(`{{ popup.html }}`);
+    {% endif %}
     {% if popup.coordinates %}
     popup_{{ loop.index }}.setLngLat({{ popup.coordinates | tojson }}).addTo(map);
     {% endif %}
@@ -141,7 +144,7 @@ map.on('load', function() {
     map.on('{{ popup.events|first }}', '{{ popup.layer_id }}', function(e) {
         popup_{{ loop.index }}
             .setLngLat(e.lngLat)
-            .setHTML(`{{ popup.html }}`)
+            {% if popup.prop %}.setHTML(e.features[0].properties['{{ popup.prop }}']){% else %}.setHTML(`{{ popup.html }}`){% endif %}
             .addTo(map);
     });
     {% endif %}
@@ -153,7 +156,7 @@ map.on('load', function() {
     map.on('mouseenter', '{{ tooltip.layer_id }}', function(e) {
         tooltip_{{ loop.index }}
             .setLngLat(e.lngLat)
-            .setHTML(`{{ tooltip.text }}`)
+            {% if tooltip.prop %}.setHTML(e.features[0].properties['{{ tooltip.prop }}']){% else %}.setHTML(`{{ tooltip.text }}`){% endif %}
             .addTo(map);
     });
     map.on('mouseleave', '{{ tooltip.layer_id }}', function() {

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3,6 +3,8 @@ from maplibreum.core import (
     Map,
     Marker,
     GeoJson,
+    GeoJsonPopup,
+    GeoJsonTooltip,
     Circle,
     CircleMarker,
     PolyLine,
@@ -283,4 +285,24 @@ def test_circlemarker_opacity():
     CircleMarker([1, 1], radius=5, fill_opacity=0.7).add_to(m)
     layer = m.layers[0]
     assert layer["definition"]["paint"]["circle-opacity"] == 0.7
+
+
+def test_geojson_popup_tooltip_properties():
+    m = Map()
+    data = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"name": "First", "desc": "A tip"},
+                "geometry": {"type": "Point", "coordinates": [0, 0]},
+            }
+        ],
+    }
+    popup = GeoJsonPopup(fields=["name"])
+    tooltip = GeoJsonTooltip(fields=["desc"])
+    GeoJson(data, popup=popup, tooltip=tooltip).add_to(m)
+    html = m.render()
+    assert "First" in html
+    assert "A tip" in html
 


### PR DESCRIPTION
## Summary
- support GeoJSON property-based popups and tooltips
- auto-attach popups and tooltips when GeoJsonPopup/GeoJsonTooltip provided
- test that feature properties appear in rendered popups and tooltips

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c2347f67cc832f9ad0057ad1111756