### PR TITLE
Support templated popups

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -10,6 +10,7 @@ from .core import (
     GeoJsonPopup,
     GeoJsonTooltip,
     LatLngPopup,
+    Popup,
 )
 from .markers import Icon, DivIcon, BeautifyIcon
 from .choropleth import Choropleth
@@ -31,6 +32,7 @@ __all__ = [
     "GeoJsonPopup",
     "GeoJsonTooltip",
     "LatLngPopup",
+    "Popup",
     "TimeDimension",
 ]
 

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -135,7 +135,7 @@ map.on('load', function() {
     {% for popup in popups %}
     var popup_{{ loop.index }} = new maplibregl.Popup({{ popup.options | tojson }});
     {% if popup.html %}
-    popup_{{ loop.index }}.setHTML(`{{ popup.html }}`);
+    popup_{{ loop.index }}.setHTML(`{{ popup.html | safe }}`);
     {% endif %}
     {% if popup.coordinates %}
     popup_{{ loop.index }}.setLngLat({{ popup.coordinates | tojson }}).addTo(map);
@@ -144,7 +144,7 @@ map.on('load', function() {
     map.on('{{ popup.events|first }}', '{{ popup.layer_id }}', function(e) {
         popup_{{ loop.index }}
             .setLngLat(e.lngLat)
-            {% if popup.prop %}.setHTML(e.features[0].properties['{{ popup.prop }}']){% else %}.setHTML(`{{ popup.html }}`){% endif %}
+            {% if popup.prop %}.setHTML(e.features[0].properties['{{ popup.prop }}']){% else %}.setHTML(`{{ popup.html | safe }}`){% endif %}
             .addTo(map);
     });
     {% endif %}

--- a/tests/test_popup_template.py
+++ b/tests/test_popup_template.py
@@ -1,0 +1,28 @@
+import pytest
+
+from maplibreum import Map, Popup
+
+
+@pytest.fixture
+def map_instance():
+    return Map()
+
+
+def test_popup_template_rendering(map_instance):
+    map_instance.add_popup(
+        template="Hello {{ name }}",
+        coordinates=[0, 0],
+        context={"name": "<World>"},
+    )
+    assert map_instance.popups[0]["html"] == "Hello &lt;World&gt;"
+    html = map_instance.render()
+    assert "Hello &lt;World&gt;" in html
+    assert "<World>" not in html
+
+
+def test_popup_object_render(map_instance):
+    tpl = Popup(template="<div>{{ value }}</div>")
+    map_instance.add_popup(html=tpl, coordinates=[0, 0], context={"value": "<b>X</b>"})
+    assert map_instance.popups[0]["html"] == "<div>&lt;b&gt;X&lt;/b&gt;</div>"
+    html = map_instance.render()
+    assert "<div>&lt;b&gt;X&lt;/b&gt;</div>" in html


### PR DESCRIPTION
## Summary
- Add Popup class for rendering HTML or Jinja2-based popup content
- Allow Map.add_popup and FeatureGroup.add_popup to render templates with context
- Safely inject rendered popup HTML in map template
- Test popup rendering and escaping

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c3aa446148832fb336829dd88a1372