### PR TITLE
Support GeoJSON property popups and tooltips

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -48,11 +48,18 @@ class Popup:
 
 
 class GeoJsonPopup:
-    """Generate HTML popups from GeoJSON feature properties."""
+    """Generate HTML snippets from GeoJSON feature properties."""
 
     def __init__(self, fields, aliases=None, labels=True, style=""):
-        self.fields = fields
-        self.aliases = aliases or fields
+        self.fields = (
+            list(fields) if isinstance(fields, (list, tuple)) else [fields]
+        )
+        if aliases is None:
+            self.aliases = self.fields
+        else:
+            self.aliases = (
+                list(aliases) if isinstance(aliases, (list, tuple)) else [aliases]
+            )
         self.labels = labels
         self.style = style
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -299,10 +299,11 @@ def test_geojson_popup_tooltip_properties():
             }
         ],
     }
-    popup = GeoJsonPopup(fields=["name"])
-    tooltip = GeoJsonTooltip(fields=["desc"])
+    popup = GeoJsonPopup(fields=["name"], aliases=["Title"])
+    tooltip = GeoJsonTooltip(fields=["desc"], labels=False)
     GeoJson(data, popup=popup, tooltip=tooltip).add_to(m)
     html = m.render()
-    assert "First" in html
+    assert "<b>Title</b>: First" in html
     assert "A tip" in html
+    assert "<b>desc</b>" not in html
 


### PR DESCRIPTION
## Summary
- Add `GeoJsonPopup` and `GeoJsonTooltip` helpers to render feature properties as HTML
- Ensure `GeoJson` attaches rendered popups/tooltips to layer features
- Test property driven popups and tooltips

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c3b3ae64c4832f985ad401dc6f60eb