### PR TITLE
Add floating image overlay support

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -379,6 +379,24 @@ class Map:
             overlay["layers"] = layers
         self.overlays.append(overlay)
 
+    def add_float_image(self, image_url, position="top-left", width=None):
+        """Add a floating image anchored to a map corner.
+
+        Parameters
+        ----------
+        image_url : str
+            URL of the image to display.
+        position : str, optional
+            One of ``'top-left'``, ``'top-right'``, ``'bottom-left'`` or
+            ``'bottom-right'``. Defaults to ``'top-left'``.
+        width : int, optional
+            Width of the image in pixels.
+        """
+
+        img = FloatImage(image_url, position=position, width=width)
+        self.float_images.append(img)
+        return img
+
     def add_wms_layer(
         self,
         base_url,
@@ -1482,13 +1500,26 @@ class ImageOverlay:
 
 
 class FloatImage:
-    """Add a floating image to the map."""
+    """Add an image floating above the map at a fixed position."""
 
-    def __init__(self, image_url, bottom=None, left=None, width=None):
+    _POSITION_STYLES = {
+        "top-left": "top: 0px; left: 0px;",
+        "top-right": "top: 0px; right: 0px;",
+        "bottom-left": "bottom: 0px; left: 0px;",
+        "bottom-right": "bottom: 0px; right: 0px;",
+    }
+
+    def __init__(self, image_url, position="top-left", width=None):
         self.image_url = image_url
-        self.bottom = bottom
-        self.left = left
+        self.position = position
         self.width = width
+
+    @property
+    def style(self):
+        base = self._POSITION_STYLES.get(self.position, "")
+        if self.width is not None:
+            base += f" width: {self.width}px;"
+        return base
 
     def add_to(self, map_instance):
         map_instance.float_images.append(self)

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -60,7 +60,7 @@
 <body>
     <div id="map">
         {% for image in float_images %}
-        <img src="{{ image.image_url }}" style="position: absolute; bottom: {{ image.bottom }}px; left: {{ image.left }}px; width: {{ image.width }}px; z-index: 999;">
+        <img src="{{ image.image_url }}" style="position: absolute; {{ image.style }} z-index: 999;">
         {% endfor %}
         {% for legend in legends %}
         <div class="maplibreum-legend">{{ legend | safe }}</div>

--- a/tests/test_float_image.py
+++ b/tests/test_float_image.py
@@ -1,17 +1,25 @@
 import pytest
-from maplibreum.core import Map, FloatImage
+from maplibreum.core import Map
 
-def test_float_image():
+
+@pytest.mark.parametrize(
+    "position, css_rules",
+    [
+        ("top-left", ("top: 0px", "left: 0px")),
+        ("top-right", ("top: 0px", "right: 0px")),
+        ("bottom-left", ("bottom: 0px", "left: 0px")),
+        ("bottom-right", ("bottom: 0px", "right: 0px")),
+    ],
+)
+def test_float_image_positions(position, css_rules):
     m = Map()
     image_url = "https://example.com/image.png"
-    float_image = FloatImage(image_url, bottom=10, left=10, width=100)
-    float_image.add_to(m)
+    m.add_float_image(image_url, position=position)
 
     assert len(m.float_images) == 1
-    assert m.float_images[0] == float_image
 
     html = m.render()
     assert image_url in html
-    assert "bottom: 10px" in html
-    assert "left: 10px" in html
-    assert "width: 100px" in html
+    for rule in css_rules:
+        assert rule in html
+


### PR DESCRIPTION
## Summary
- support floating images anchored to map corners
- expose Map.add_float_image convenience API
- test floating image placement for all corners

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c47a9b15c0832fb5238bec99d80102