### PR TITLE
Prepare project for initial release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-09-15
+### Added
+- Initial MapLibre integration with a `Map` object that renders interactive maps in notebooks and exported HTML.
+- Layer primitives including GeoJSON overlays, choropleths, clustered data sources, and time-aware visualisations.
+- Media overlays for static imagery and video along with floating image support.
+- Marker utilities with HTML, DivIcon, and Beautify icon support plus draggable markers and clustering helpers.
+- Map controls such as mini map, measure, search, draw tools, layer toggles, and camera helpers.
+- Terrain, sky, and fog helpers alongside expression builders for data-driven styling.
+- Event wiring for click, move, and draw callbacks in Jupyter environments.
+
+[0.1.0]: https://github.com/kauevestena/maplibreum_prototype/releases/tag/v0.1.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include LICENSE
+include CHANGELOG.md
 recursive-include maplibreum/templates *.html

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ color = interpolate(
 jupyter notebook examples
 ```
 
+## Changelog
+
+See the [CHANGELOG](CHANGELOG.md) for a detailed list of updates in each release.
+
 ## Contributing
 
 Contributions are welcome! Please see the [issues page](https://github.com/kauevestena/maplibreum_prototype/issues) to see what needs to be done.

--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -1,3 +1,4 @@
+from ._version import __version__
 from .core import (
     Map,
     Marker,
@@ -42,6 +43,7 @@ __all__ = [
     "MarkerCluster",
     "ClusteredGeoJson",
     "cluster_features",
+    "__version__",
 ]
 
 

--- a/maplibreum/_version.py
+++ b/maplibreum/_version.py
@@ -1,0 +1,8 @@
+"""Project version information."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,34 @@
 [build-system]
-requires = ["setuptools>=62", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "maplibreum"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A Python library for creating interactive MapLibre maps, like Folium but for MapLibre."
-readme = "README.md"
+readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"
+license-files = ["LICENSE"]
+requires-python = ">=3.8"
 authors = [
   {name = "Kauê de Moraes Vestena", email = "kauemv2@gmail.com"}
 ]
 keywords = ["map", "mapping", "geospatial", "GIS", "MapLibre", "Jupyter"]
 classifiers = [
-  "Programming Language :: Python :: 3",
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
   "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: GIS",
+  "Framework :: Jupyter",
 ]
 dependencies = [
   "Jinja2>=3.0",
-
   "MarkupSafe>=2.0",
   "ipython>=8.0",
 ]
@@ -26,6 +36,7 @@ dependencies = [
 [project.urls]
 "Source" = "https://github.com/kauevestena/maplibreum_prototype"
 "Issues" = "https://github.com/kauevestena/maplibreum_prototype/issues"
+"Changelog" = "https://github.com/kauevestena/maplibreum_prototype/blob/main/CHANGELOG.md"
 
 [tool.setuptools]
 packages = ["maplibreum"]
@@ -33,6 +44,9 @@ include-package-data = false
 
 [tool.setuptools.package-data]
 maplibreum = ["templates/*.html"]
+
+[tool.setuptools.dynamic]
+version = {attr = "maplibreum._version.__version__"}
 
 [tool.pytest.ini_options]
 testpaths = [


### PR DESCRIPTION
## Summary
- add a changelog for v0.1.0 and link it from the README so release notes are easy to find
- expose `maplibreum.__version__` and drive packaging metadata from a dedicated version module
- refresh project metadata (Python requirement, classifiers, license handling, changelog inclusion) ahead of the first PyPI build

## Testing
- pytest
- python -m build

------
https://chatgpt.com/codex/tasks/task_b_68c83f0cad9c832fb6b7091beb831f7f