### PR TITLE
Add creative MapLibreum tutorial notebook

### DIFF
--- a/examples/creative_maplibreum_examples.ipynb
+++ b/examples/creative_maplibreum_examples.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4b852aa8",
+   "metadata": {},
+   "source": [
+    "# Creative MapLibreum Examples & Tutorials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b701e9e",
+   "metadata": {},
+   "source": [
+    "MapLibreum ships with a curated set of base styles (such as `basic`, `streets`, and `satellite`) so you can start with a clean and familiar look straight away."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1560734",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8b50fdc",
+   "metadata": {},
+   "source": [
+    "## 1. Quick Start: Hello MapLibreum\n",
+    "Display a map centered on New York City and add a friendly greeting marker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "253a7df0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from maplibreum import Map\n",
+    "\n",
+    "m = Map(center=[40.7128, -74.0060], zoom=12)\n",
+    "m.add_marker(popup=\"Welcome to NYC!\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37467ee4",
+   "metadata": {},
+   "source": [
+    "`add_marker` lets you customize coordinates, popup text, marker color, clustering, icons, tooltips, and draggability."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e823e79",
+   "metadata": {},
+   "source": [
+    "## 2. Custom Icons & Tooltips\n",
+    "Use a BeautifyIcon for eye-catching markers that provide extra context to your users."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e62fb29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from maplibreum import Map\n",
+    "from maplibreum.markers import BeautifyIcon\n",
+    "\n",
+    "m = Map(center=[48.8566, 2.3522], zoom=13)\n",
+    "icon = BeautifyIcon(icon=\"fa fa-coffee\", background_color=\"#d35400\")\n",
+    "m.add_marker(coordinates=[48.8566, 2.3522],\n",
+    "             icon=icon,\n",
+    "             tooltip=\"Coffee shop\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34326245",
+   "metadata": {},
+   "source": [
+    "`BeautifyIcon` accepts icon classes, colors, and shapes, making markers visually rich."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b3c0818",
+   "metadata": {},
+   "source": [
+    "## 3. Visualizing Density with Heatmaps\n",
+    "Convert point data (for example, earthquakes) into a density heatmap for quick pattern recognition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c347156",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from maplibreum import Map\n",
+    "\n",
+    "geojson = {\"type\": \"FeatureCollection\", \"features\": []}  # fill with point features\n",
+    "source = {\"type\": \"geojson\", \"data\": geojson}\n",
+    "\n",
+    "m = Map(center=[37.7749, -122.4194], zoom=10)\n",
+    "m.add_heatmap_layer(\"quakes\", source)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac859f5c",
+   "metadata": {},
+   "source": [
+    "Heatmaps use sensible defaults for radius, intensity, opacity, and color gradient. Override them with the `paint` argument for more control."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71dbccf3",
+   "metadata": {},
+   "source": [
+    "## 4. Choropleth Map\n",
+    "Shade regions based on attribute values such as population or median income."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62c3d290",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from maplibreum import Map, Choropleth\n",
+    "\n",
+    "# geojson_polygons: FeatureCollection with polygon features\n",
+    "# pop_data: dictionary mapping feature IDs to population counts\n",
+    "m = Map()\n",
+    "Choropleth(geojson_polygons, pop_data, legend_title=\"Population\").add_to(m)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2cdd7c62",
+   "metadata": {},
+   "source": [
+    "The `Choropleth` class computes data bins, colors each feature, and adds a legend automatically."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffba709c",
+   "metadata": {},
+   "source": [
+    "## 5. Marker Clustering\n",
+    "Group many markers together for a cleaner view while still conveying density."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee7c4b32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from maplibreum import Map\n",
+    "import random\n",
+    "\n",
+    "m = Map(center=[0, 0], zoom=2)\n",
+    "points = {\n",
+    "    \"type\": \"FeatureCollection\",\n",
+    "    \"features\": [\n",
+    "        {\"type\": \"Feature\",\n",
+    "         \"geometry\": {\"type\": \"Point\",\n",
+    "                       \"coordinates\": [random.uniform(-180, 180),\n",
+    "                                       random.uniform(-85, 85)]}}\n",
+    "        for _ in range(500)\n",
+    "    ]\n",
+    "}\n",
+    "m.add_clustered_geojson(points)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34d261fc",
+   "metadata": {},
+   "source": [
+    "`add_clustered_geojson` sets up a clustered GeoJSON source and layers, letting MapLibre handle cluster rendering and counts."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97875719",
+   "metadata": {},
+   "source": [
+    "## 6. Time-Lapse Playback\n",
+    "Animate timestamped features—ideal for tracking movement or events over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38abd1ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from maplibreum import Map\n",
+    "from maplibreum.timedimension import TimeDimension\n",
+    "\n",
+    "data = {\n",
+    "    \"type\": \"FeatureCollection\",\n",
+    "    \"features\": [\n",
+    "        {\"type\": \"Feature\",\n",
+    "         \"geometry\": {\"type\": \"Point\", \"coordinates\": [-0.1, 51.5]},\n",
+    "         \"properties\": {\"time\": \"2024-01-01T00:00:00Z\"}},\n",
+    "        # add more features with increasing timestamps\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "m = Map()\n",
+    "TimeDimension(data, options={\"interval\": 1000}).add_to(m)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d81ec33e",
+   "metadata": {},
+   "source": [
+    "`TimeDimension` wraps timestamped GeoJSON and exposes playback options such as interval speed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec2e9f4f",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "### Notes\n",
+    "- Replace API keys or data sources (map tiles, GeoJSON) with your own where necessary.\n",
+    "- Jupyter Notebook is recommended for interactive display (`pip install jupyter`).\n",
+    "\n",
+    "### Testing\n",
+    "No automated tests are run inside this notebook; code cells illustrate the API usage."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Creative MapLibreum Examples & Tutorials notebook under examples
- cover quick start, custom icons, heatmaps, choropleths, clustering, and time-lapse playback snippets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c8a4d49b10832f8a093b8b20e4dae6