### PR TITLE
Embed map reprs in iframe and fix map IDs

### DIFF
--- a/examples/README
+++ b/examples/README
@@ -1,0 +1,9 @@
+# Examples
+
+This directory contains example notebooks and rendered HTML outputs that showcase MapLibreum features.
+
+## Displaying maps inside notebooks
+
+Simply creating a `Map` instance (for example `m = Map(...)`) and evaluating `m` in a notebook cell now renders the map inside an embedded `<iframe>` thanks to the object's `_repr_html_` implementation.
+
+If you need to control the size or other iframe attributes explicitly, call `m.display_in_notebook(width="100%", height="500px")` (or with your preferred dimensions) to use the dedicated helper instead.

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -1,3 +1,4 @@
+import html
 import json
 import math
 import os
@@ -992,13 +993,14 @@ class Map:
             The rendered HTML.
         """
         # Inject custom CSS to adjust the map div if needed
-        # The template expects #map { width: ..., height: ... } to be set via
-        # custom_css if desired.
-        dimension_css = f"#map {{ width: {self.width}; height: {self.height}; }}"
+        # The template expects the unique map container ID to control sizing.
+        dimension_css = (
+            f"#{self.map_id} {{ width: {self.width}; height: {self.height}; }}"
+        )
         marker_css = "\n".join(self.marker_css)
         final_custom_css = "\n".join([dimension_css, marker_css, self.custom_css])
         map_options = {
-            "container": "map",
+            "container": self.map_id,
             "style": self.map_style,
         }
         if self.bounds is None:
@@ -1051,7 +1053,13 @@ class Map:
 
     def _repr_html_(self):
         """Jupyter Notebook display method."""
-        return self.render()
+        iframe_id = f"{self.map_id}_iframe"
+        escaped_html = html.escape(self.render(), quote=True)
+        style = f"width: {self.width}; height: {self.height}; border: none;"
+        return (
+            f'<iframe id="{iframe_id}" srcdoc="{escaped_html}" '
+            f'style="{style}" loading="lazy"></iframe>'
+        )
 
     def display_in_notebook(self, width="100%", height="500px"):
         """Display the map in a Jupyter Notebook with a specific size.

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -23,7 +23,7 @@
             padding: 0;
         }
 
-        #map {
+        #{{ map_id }} {
             width: 100%;
             height: 500px;
             position: relative;
@@ -58,7 +58,7 @@
     </style>
 </head>
 <body>
-    <div id="map">
+    <div id="{{ map_id }}">
         {% for image in float_images %}
         <img src="{{ image.image_url }}" style="position: absolute; {{ image.style }} z-index: 999;">
         {% endfor %}
@@ -96,7 +96,7 @@
 
         // Function to show error message when MapLibre fails to load
         function showMapError(message) {
-            const mapDiv = document.getElementById('map');
+            const mapDiv = document.getElementById('{{ map_id }}');
             if (mapDiv) {
                 mapDiv.innerHTML = `
                     <div style="

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -19,7 +19,7 @@ def test_map_render_contains_style(map_instance):
     html = map_instance.render()
     assert isinstance(html, str)
     assert map_instance.map_style in html
-    assert '<div id="map"' in html
+    assert f'<div id="{map_instance.map_id}"' in html
 
 
 def test_add_tile_layer(map_instance):

--- a/tests/test_repr_html.py
+++ b/tests/test_repr_html.py
@@ -1,0 +1,10 @@
+from maplibreum.core import Map
+
+
+def test_repr_html_returns_iframe():
+    m = Map()
+    html = m._repr_html_()
+
+    assert html.strip().startswith("<iframe")
+    assert "srcdoc=" in html
+    assert f'id="{m.map_id}_iframe"' in html


### PR DESCRIPTION
## Summary
- render `_repr_html_` via an iframe that injects the rendered HTML with unique IDs derived from `map_id`
- update the map template and related tests to use per-map container IDs so multiple maps can coexist
- document the new notebook display behavior and add a regression test for the iframe repr

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c96e88c1c8832fb5c627ffeb7f9665