### PR TITLE
Feat: Add 3D terrain example and refactor codebase

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -2,19 +2,18 @@ from ._version import __version__
 from .choropleth import Choropleth
 from .cluster import ClusteredGeoJson, MarkerCluster, cluster_features
 from .core import (GeoJson, GeoJsonPopup, GeoJsonTooltip, ImageOverlay,
-                   LatLngPopup, Legend, Map, Marker, MeasureControl,
-                   MiniMapControl, Popup, SearchControl, Tooltip, VideoOverlay)
+                   LatLngPopup, Legend, Map, Marker, Popup, Tooltip, VideoOverlay)
 from .markers import BeautifyIcon, DivIcon, Icon
 from .timedimension import TimeDimension
+from . import controls
+from . import sources
+from . import layers
 
 __all__ = [
     "Map",
     "Marker",
     "GeoJson",
     "Legend",
-    "MiniMapControl",
-    "MeasureControl",
-    "SearchControl",
     "Choropleth",
     "Icon",
     "DivIcon",
@@ -31,4 +30,7 @@ __all__ = [
     "ClusteredGeoJson",
     "cluster_features",
     "__version__",
+    "controls",
+    "sources",
+    "layers",
 ]

--- a/maplibreum/controls.py
+++ b/maplibreum/controls.py
@@ -1,0 +1,97 @@
+from .styles import MAP_STYLES
+
+
+class NavigationControl:
+    def __init__(self, visualizePitch=False, showZoom=False, showCompass=False):
+        self.options = {
+            "visualizePitch": visualizePitch,
+            "showZoom": showZoom,
+            "showCompass": showCompass,
+        }
+
+    def to_dict(self):
+        return self.options
+
+
+class TerrainControl:
+    def __init__(self, source, exaggeration=1):
+        self.options = {"source": source, "exaggeration": exaggeration}
+
+    def to_dict(self):
+        return self.options
+
+
+class MiniMapControl:
+    """Configuration object for the MiniMap plugin control."""
+
+    def __init__(self, style="basic", zoom_level=6):
+        """Initialize a MiniMapControl.
+
+        Parameters
+        ----------
+        style : str, optional
+            The map style to use for the minimap.
+        zoom_level : int, optional
+            The zoom level offset for the minimap.
+        """
+        if style in MAP_STYLES:
+            self.style = MAP_STYLES[style]
+        else:
+            self.style = style
+        self.zoom_level = zoom_level
+
+    def to_dict(self):
+        """Serialize configuration for template usage."""
+        return {"style": self.style, "zoomLevelOffset": self.zoom_level}
+
+
+class SearchControl:
+    """Configuration for a search/geocoder control."""
+
+    def __init__(self, provider="maptiler", api_key=None, **options):
+        """Initialize a SearchControl.
+
+        Parameters
+        ----------
+        provider : str, optional
+            The search provider to use.
+        api_key : str, optional
+            The API key for the search provider.
+        options : dict, optional
+            Additional options for the search control.
+        """
+        self.provider = provider
+        self.api_key = api_key
+        self.options = options
+
+    def to_dict(self):
+        """Serialize configuration for template usage.
+
+        Returns
+        -------
+        dict
+            The dictionary representation of the search control options.
+        """
+        data = {"provider": self.provider}
+        if self.api_key is not None:
+            data["apiKey"] = self.api_key
+        data.update(self.options)
+        return data
+
+
+class MeasureControl:
+    """Configuration for the map measure tool."""
+
+    def __init__(self, **options):
+        """Initialize a MeasureControl.
+
+        Parameters
+        ----------
+        options : dict, optional
+            Options for the measure control.
+        """
+        self.options = options
+
+    def to_dict(self):
+        """Serialize configuration for template usage."""
+        return self.options

--- a/maplibreum/layers.py
+++ b/maplibreum/layers.py
@@ -1,0 +1,19 @@
+class Layer:
+    def __init__(self, id, type, source, **kwargs):
+        self.id = id
+        self.type = type
+        self.source = source
+        self.options = kwargs
+
+    def to_dict(self):
+        return {"id": self.id, "type": self.type, "source": self.source, **self.options}
+
+
+class RasterLayer(Layer):
+    def __init__(self, id, source, **kwargs):
+        super().__init__(id, "raster", source, **kwargs)
+
+
+class HillshadeLayer(Layer):
+    def __init__(self, id, source, **kwargs):
+        super().__init__(id, "hillshade", source, **kwargs)

--- a/maplibreum/sources.py
+++ b/maplibreum/sources.py
@@ -1,0 +1,18 @@
+class Source:
+    def __init__(self, type, **kwargs):
+        self.type = type
+        self.options = kwargs
+
+    @property
+    def __dict__(self):
+        return {"type": self.type, **self.options}
+
+
+class RasterSource(Source):
+    def __init__(self, tiles, tileSize=256, **kwargs):
+        super().__init__("raster", tiles=tiles, tileSize=tileSize, **kwargs)
+
+
+class RasterDemSource(Source):
+    def __init__(self, url, tileSize=256, **kwargs):
+        super().__init__("raster-dem", url=url, tileSize=tileSize, **kwargs)

--- a/maplibreum/styles.py
+++ b/maplibreum/styles.py
@@ -1,0 +1,9 @@
+# Predefined map styles
+MAP_STYLES = {
+    "basic": "https://demotiles.maplibre.org/style.json",
+    "streets": "https://api.maptiler.com/maps/streets/style.json?key=YOUR_API_KEY",
+    "satellite": "https://api.maptiler.com/maps/satellite/style.json?key=YOUR_API_KEY",
+    "topo": "https://api.maptiler.com/maps/topo/style.json?key=YOUR_API_KEY",
+    "dark": "https://api.maptiler.com/maps/darkmatter/style.json?key=YOUR_API_KEY",
+    "light": "https://api.maptiler.com/maps/positron/style.json?key=YOUR_API_KEY",
+}

--- a/misc/maplibre_examples/README.md
+++ b/misc/maplibre_examples/README.md
@@ -146,6 +146,7 @@ This roadmap tracks the systematic implementation of all 123 official MapLibre G
 - `add-a-geojson-line` - GeoJSON LineString layers with styling
 - `add-an-icon-to-the-map` - Custom icon symbol layers
 - `display-a-popup-on-click` - Interactive popups with event handling
+- `3d-terrain` - 3D terrain rendering
 
 **🎯 Next Priority Examples (Phase 1 continuation):**
 - `add-a-geojson-polygon` - GeoJSON polygon rendering and styling

--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -4,7 +4,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/3d-terrain/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/3d-terrain.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "add-a-3d-model-to-globe-using-threejs": {

--- a/tests/test_examples/test_3d_terrain.py
+++ b/tests/test_examples/test_3d_terrain.py
@@ -1,0 +1,51 @@
+from maplibreum import Map, controls, sources, layers
+
+def test_3d_terrain():
+    m = Map(
+        map_style={
+            "version": 8,
+            "sources": {
+                "osm": sources.RasterSource(
+                    tiles=["https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"],
+                    tileSize=256,
+                    attribution="&copy; OpenStreetMap Contributors",
+                    maxzoom=19,
+                ).__dict__,
+                "terrainSource": sources.RasterDemSource(
+                    url="https://demotiles.maplibre.org/terrain-tiles/tiles.json",
+                    tileSize=256,
+                ).__dict__,
+                "hillshadeSource": sources.RasterDemSource(
+                    url="https://demotiles.maplibre.org/terrain-tiles/tiles.json",
+                    tileSize=256,
+                ).__dict__,
+            },
+            "layers": [
+                layers.RasterLayer(id="osm", source="osm").to_dict(),
+                layers.HillshadeLayer(
+                    id="hills",
+                    source="hillshadeSource",
+                    layout={"visibility": "visible"},
+                    paint={"hillshade-shadow-color": "#473B24"},
+                ).to_dict(),
+            ],
+            "terrain": {"source": "terrainSource", "exaggeration": 1},
+            "sky": {},
+        },
+        center=[11.39085, 47.27574],
+        zoom=12,
+        pitch=70,
+        map_options={
+            "hash": True,
+            "maxZoom": 18,
+            "maxPitch": 85,
+        },
+    )
+    m.add_control(
+        controls.NavigationControl(
+            visualizePitch=True,
+            showZoom=True,
+            showCompass=True,
+        )
+    )
+    m.add_control(controls.TerrainControl(source="terrainSource", exaggeration=1))


### PR DESCRIPTION
This change adds a new test case for the `3d-terrain` example from the MapLibre GL JS documentation.

To support this example, the codebase has been refactored to be more modular.

New modules have been created for controls (`maplibreum/controls.py`), sources (`maplibreum/sources.py`), layers (`maplibreum/layers.py`), and styles (`maplibreum/styles.py`).

The `NavigationControl` and `TerrainControl` classes have been added.

The `add_control` method in the `Map` class has been updated to handle control objects.

The `status.json` and `README.md` files have been updated to reflect the completion of the example.