### PR TITLE
Improve control helpers and expand Phase 2 coverage

### DIFF
--- a/maplibreum/layers.py
+++ b/maplibreum/layers.py
@@ -1,19 +1,113 @@
+"""Lightweight helpers for constructing MapLibre layer definitions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
 class Layer:
-    def __init__(self, id, type, source, **kwargs):
+    """Generic representation of a MapLibre style layer."""
+
+    def __init__(
+        self,
+        id: str,
+        type: str,
+        source: Optional[str] = None,
+        *,
+        paint: Optional[Dict[str, Any]] = None,
+        layout: Optional[Dict[str, Any]] = None,
+        filter: Optional[Any] = None,
+        minzoom: Optional[float] = None,
+        maxzoom: Optional[float] = None,
+        source_layer: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        slot: Optional[str] = None,
+        **extra: Any,
+    ) -> None:
+        """Store layer configuration for later serialization."""
+
         self.id = id
         self.type = type
-        self.source = source
-        self.options = kwargs
+        self._options: Dict[str, Any] = {}
 
-    def to_dict(self):
-        return {"id": self.id, "type": self.type, "source": self.source, **self.options}
+        if source is not None:
+            self._options["source"] = source
+        if paint is not None:
+            self._options["paint"] = paint
+        if layout is not None:
+            self._options["layout"] = layout
+        if filter is not None:
+            self._options["filter"] = filter
+        if minzoom is not None:
+            self._options["minzoom"] = minzoom
+        if maxzoom is not None:
+            self._options["maxzoom"] = maxzoom
+        if source_layer is not None:
+            self._options["source-layer"] = source_layer
+        if metadata is not None:
+            self._options["metadata"] = metadata
+        if slot is not None:
+            self._options["slot"] = slot
+
+        # Include any additional keyword arguments, skipping ``None`` values.
+        for key, value in extra.items():
+            if value is not None:
+                self._options[key] = value
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the layer definition as a plain dictionary."""
+
+        return {"id": self.id, "type": self.type, **self._options}
 
 
 class RasterLayer(Layer):
-    def __init__(self, id, source, **kwargs):
+    def __init__(self, id: str, source: str, **kwargs: Any) -> None:
         super().__init__(id, "raster", source, **kwargs)
 
 
 class HillshadeLayer(Layer):
-    def __init__(self, id, source, **kwargs):
+    def __init__(self, id: str, source: str, **kwargs: Any) -> None:
         super().__init__(id, "hillshade", source, **kwargs)
+
+
+class ColorReliefLayer(Layer):
+    def __init__(self, id: str, source: str, **kwargs: Any) -> None:
+        super().__init__(id, "color-relief", source, **kwargs)
+
+
+class FillLayer(Layer):
+    def __init__(self, id: str, source: Optional[str] = None, **kwargs: Any) -> None:
+        super().__init__(id, "fill", source, **kwargs)
+
+
+class LineLayer(Layer):
+    def __init__(self, id: str, source: Optional[str] = None, **kwargs: Any) -> None:
+        super().__init__(id, "line", source, **kwargs)
+
+
+class CircleLayer(Layer):
+    def __init__(self, id: str, source: Optional[str] = None, **kwargs: Any) -> None:
+        super().__init__(id, "circle", source, **kwargs)
+
+
+class SymbolLayer(Layer):
+    def __init__(self, id: str, source: Optional[str] = None, **kwargs: Any) -> None:
+        super().__init__(id, "symbol", source, **kwargs)
+
+
+class FillExtrusionLayer(Layer):
+    def __init__(self, id: str, source: Optional[str] = None, **kwargs: Any) -> None:
+        super().__init__(id, "fill-extrusion", source, **kwargs)
+
+
+__all__ = [
+    "Layer",
+    "RasterLayer",
+    "HillshadeLayer",
+    "ColorReliefLayer",
+    "FillLayer",
+    "LineLayer",
+    "CircleLayer",
+    "SymbolLayer",
+    "FillExtrusionLayer",
+]

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -193,7 +193,7 @@ function _storeMeasure(data) {
     }
 }
 var measure = new maplibreGLMeasures(Object.assign({{ measure_control_options | tojson }}, {onCreate: _storeMeasure, onRender: _storeMeasure}));
-map.addControl(measure, 'top-left');
+map.addControl(measure, '{{ measure_control_position }}');
 {% endif %}
 
 map.on('load', function() {
@@ -203,6 +203,19 @@ map.on('load', function() {
     // Add sources
     {% for source in sources %}
     map.addSource("{{ source.name }}", {{ source.definition | tojson | safe }});
+    {% endfor %}
+
+    // Register images used by style layers
+    {% for image in images %}
+    {% if image.url %}
+    map.loadImage({{ image.url | tojson }}).then(function(loadedImage) {
+        map.addImage({{ image.id | tojson }}, loadedImage.data{% if image.options %}, {{ image.options | tojson | safe }}{% endif %});
+    }).catch(function(err) {
+        console.error('Failed to load image {{ image.id }}', err);
+    });
+    {% else %}
+    map.addImage({{ image.id | tojson }}, {{ image.data | tojson | safe }}{% if image.options %}, {{ image.options | tojson | safe }}{% endif %});
+    {% endif %}
     {% endfor %}
 
     {% if terrain %}

--- a/misc/maplibre_examples/README.md
+++ b/misc/maplibre_examples/README.md
@@ -137,6 +137,8 @@ When converting JavaScript examples to Python:
 
 This roadmap tracks the systematic implementation of all 123 official MapLibre GL JS examples to ensure comprehensive feature coverage and compatibility. This shall be updated every iteration.
 
+**Current Coverage:** 28/123 examples completed (22.8%).
+
 #### Phase 1: Core Functionality (13/123 completed - 10.6%)
 
 **✅ Completed Examples:**
@@ -162,14 +164,66 @@ This roadmap tracks the systematic implementation of all 123 official MapLibre G
 - `draw-geojson-points` - Styling raw GeoJSON points
 - `display-a-remote-svg-symbol` - External asset symbol usage
 
-#### Phase 2: Advanced Styling & Layers (Target: 20% coverage)
+#### Phase 2: Advanced Styling & Layers (15/123 completed - 12.2%)
 
-**Planned Examples:**
-- Polygon styling and patterns
-- Multiple layer types (fill, line, circle, heatmap)
-- Data-driven styling expressions
-- Layer filtering and querying
-- Custom style specifications
+**✅ Completed Examples (Milestone reached):**
+- `add-a-pattern-to-a-polygon` – Pattern fills via `Map.add_image` and `FillLayer` helpers.
+- `add-a-color-relief-layer` – Custom raster-dem color ramp rendered through `ColorReliefLayer`.
+- `add-a-hillshade-layer` – Hillshade styling with layout/paint passthrough.
+- `add-a-multidirectional-hillshade-layer` – Advanced hillshade paint options (illumination + highlight).
+- `add-a-new-layer-below-labels` – Symbol overlays inserted with the `before` parameter.
+- `create-a-gradient-line-using-an-expression` – Line metrics and gradient expressions.
+- `style-lines-with-a-data-driven-property` – Feature-driven styling using `get` expressions.
+- `change-building-color-based-on-zoom-level` – Zoom-interpolated extrusion coloring.
+- `visualize-population-density` – Nested `let`/`var` expressions for thematic fills.
+- `display-a-globe-with-a-fill-extrusion-layer` – Globe projection with extruded GeoJSON polygons.
+- `add-a-vector-tile-source` – External vector source with styled waterways.
+- `add-a-raster-tile-source` – Raster tile overlay registered through `RasterLayer`.
+- `add-contour-lines` – Combined hillshade, contour, and label layers built through helper wrappers.
+- `display-a-remote-svg-symbol` – Remote SVG sprites loaded via `Map.add_image` and symbol layouts.
+- `filter-within-a-layer` – Circle-layer filters expressed with helper-managed expression arrays.
+
+**🧭 Dependency Inventory & Priorities**
+
+| Example | Category | Key Dependencies | Helper Alignment |
+| --- | --- | --- | --- |
+| `add-a-pattern-to-a-polygon` | Pattern fills | Requires runtime image registration | `Map.add_image` + `FillLayer` |
+| `visualize-population-density` | Expressions | Nested `let`/`var` and `to-color` expressions | Raw expression lists with layer wrappers |
+| `change-building-color-based-on-zoom-level` | Extrusions & expressions | Zoom-driven color/height interpolation | `FillExtrusionLayer` paint passthrough |
+| `display-a-globe-with-a-fill-extrusion-layer` | Globe + extrusions | Projection option and extrusion paint | `map_options['projection']` + `FillExtrusionLayer` |
+| `create-a-gradient-line-using-an-expression` | Line gradients | `lineMetrics` and `line-gradient` | `LineLayer` layout/paint passthrough |
+| `style-lines-with-a-data-driven-property` | Data driven styling | Feature property accessors | `LineLayer` with expression paint |
+| `add-a-color-relief-layer` | Raster styling | Color relief paint arrays | `ColorReliefLayer` helper |
+| `add-a-hillshade-layer` | Raster hillshade | Shadow/exaggeration tuning | `HillshadeLayer` helper |
+| `add-a-multidirectional-hillshade-layer` | Raster hillshade | Illumination direction and highlight colors | `HillshadeLayer` helper |
+| `add-a-new-layer-below-labels` | Layer ordering | `before` placement and symbol layout | `SymbolLayer` + `Map.add_layer(before=...)` |
+| `add-a-vector-tile-source` | Vector source | External tile registration and line styling | `Map.add_source` + `LineLayer` |
+| `add-a-raster-tile-source` | Raster source | Remote raster tiles | `Map.add_source` + `RasterLayer` |
+| `add-contour-lines` | Multi-layer styling | Hillshade tiles with contour vectors and label expressions | `HillshadeLayer` + `LineLayer` + `SymbolLayer` |
+| `display-a-remote-svg-symbol` | Pattern icons | Remote sprite loading and icon layout overrides | `Map.add_image` + `SymbolLayer` |
+| `filter-within-a-layer` | Expressions | Compound property filters on circle paints | `CircleLayer` filter serialization |
+
+**📝 Pending Phase 2 Inventory (prioritized by helper readiness):**
+
+| Example | Category | Key Dependencies | Helper Alignment | Priority |
+| --- | --- | --- | --- | --- |
+| `draw-a-circle` | Expressions & drawing | GeoJSON circle generation and circle layer styling | Supported via GeoJSON sources + `CircleLayer` | High |
+| `fit-to-the-bounds-of-a-linestring` | Camera & multi-layer | Automatic extent fitting for line sources | `Map.fit_bounds` + line helpers | High |
+| `display-line-that-crosses-180th-meridian` | Multi-layer styling | Wrapping-aware line rendering & map world copies | `LineLayer` + `map_options['renderWorldCopies']` | High |
+| `create-a-heatmap-layer-on-a-globe-with-terrain-elevation` | Multi-layer & terrain | Heatmap paint plus globe projection & terrain exaggeration | `Map.add_heatmap_layer`, `set_terrain`, globe projection options | High |
+| `change-a-layers-color-with-buttons` | Expressions & UI | DOM events updating paint properties | Filters/paints supported; needs UI wiring via `extra_js` | Medium |
+| `filter-layer-symbols-using-global-state` | Expressions | Feature filters toggled from Python state | Filter serialization ready; requires shared state helpers | Medium |
+| `filter-symbols-by-text-input` | Expressions & UI | Text input driving symbol layer filters | Filter helpers available; needs input binding | Medium |
+| `center-the-map-on-a-clicked-symbol` | Interactivity | Symbol click events triggering camera transitions | Map event API exists; requires scripted callbacks | Medium |
+| `animate-a-line` | Animation | Timed updates to line source data | Data updates possible via callbacks; needs animation loop glue | Medium |
+| `animate-symbol-to-follow-the-mouse` | Animation & events | Pointer tracking and dynamic symbol placement | Event hooks exist; requires continuous update bridge | Medium |
+| `add-a-custom-layer-with-tiles-to-a-globe` | Custom layers | WebGL custom layer registration on globe projection | Custom layer hooks missing | Low |
+| `add-a-custom-style-layer` | Custom layers | Raw WebGL style layer integration | Custom layer hooks missing | Low |
+| `add-a-simple-custom-layer-on-a-globe` | Custom layers | Custom render loop on globe context | Custom layer hooks missing | Low |
+| `create-deckgl-layer-using-rest-api` | Custom layers | Deck.GL interop and REST-driven styling | Requires Deck.GL adapter | Low |
+| `toggle-deckgl-layer` | Custom layers | Runtime Deck.GL layer management | Requires Deck.GL adapter | Low |
+
+These additions push Phase 2 beyond the 20% coverage milestone, validating multi-layer contour styling, remote sprite usage, and compound filter expressions through automated pytest scenarios.
 
 #### Phase 3: Interactivity & Events (Target: 35% coverage)
 

--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -60,7 +60,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-color-relief-layer/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-color-relief-layer.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "add-a-custom-layer-with-tiles-to-a-globe": {
@@ -116,7 +116,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-hillshade-layer/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-hillshade-layer.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "add-a-multidirectional-hillshade-layer": {
@@ -124,7 +124,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-multidirectional-hillshade-layer/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-multidirectional-hillshade-layer.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "add-a-new-layer-below-labels": {
@@ -132,7 +132,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-new-layer-below-labels/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-new-layer-below-labels.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "add-a-pattern-to-a-polygon": {
@@ -140,7 +140,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-pattern-to-a-polygon/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-pattern-to-a-polygon.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "add-a-raster-tile-source": {
@@ -148,7 +148,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-raster-tile-source/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-raster-tile-source.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "add-a-simple-custom-layer-on-a-globe": {
@@ -172,7 +172,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-vector-tile-source/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-vector-tile-source.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "add-a-video": {
@@ -212,7 +212,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-contour-lines/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-contour-lines.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "add-custom-icons-with-markers": {
@@ -348,7 +348,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-building-color-based-on-zoom-level/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/change-building-color-based-on-zoom-level.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "change-the-case-of-labels": {
@@ -404,7 +404,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-gradient-line-using-an-expression/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/create-a-gradient-line-using-an-expression.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "create-a-heatmap-layer-on-a-globe-with-terrain-elevation": {
@@ -484,7 +484,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-a-fill-extrusion-layer/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-a-globe-with-a-fill-extrusion-layer.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "display-a-globe-with-a-vector-map": {
@@ -556,7 +556,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-remote-svg-symbol/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-a-remote-svg-symbol.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "display-a-satellite-map": {
@@ -676,7 +676,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-within-a-layer/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/filter-within-a-layer.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "fit-a-map-to-a-bounding-box": {
@@ -868,7 +868,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/style-lines-with-a-data-driven-property/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/style-lines-with-a-data-driven-property.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "sync-movement-of-multiple-maps": {
@@ -972,7 +972,7 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/visualize-population-density.html",
-      "task_status": false
+      "task_status": true
     }
   },
   "zoom-and-planet-size-relation-on-globe": {

--- a/tests/test_examples/test_add_a_color_relief_layer.py
+++ b/tests/test_examples/test_add_a_color_relief_layer.py
@@ -1,0 +1,60 @@
+"""Test for add-a-color-relief-layer MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+COLOR_RELIEF_PAINT = {
+    "color-relief-color": [
+        "interpolate",
+        ["linear"],
+        ["elevation"],
+        400,
+        "rgb(4, 0, 108)",
+        1129.41,
+        "rgb(24, 69, 240)",
+        2041.18,
+        "rgb(160, 201, 4)",
+        2588.24,
+        "rgb(251, 194, 14)",
+        3500,
+        "rgb(215, 5, 13)",
+    ]
+}
+
+
+def test_add_a_color_relief_layer():
+    """Ensure the custom color relief style renders with correct tokens."""
+
+    style = {
+        "version": 8,
+        "sources": {
+            "terrainSource": {
+                "type": "raster-dem",
+                "url": "https://demotiles.maplibre.org/terrain-tiles/tiles.json",
+                "tileSize": 256,
+            }
+        },
+        "layers": [
+            layers.ColorReliefLayer(
+                id="color-relief",
+                source="terrainSource",
+                paint=COLOR_RELIEF_PAINT,
+            ).to_dict()
+        ],
+    }
+
+    m = Map(
+        title="Color relief",
+        map_style=style,
+        center=[11.45, 47.2],
+        zoom=10,
+        map_options={"hash": True, "renderWorldCopies": False},
+    )
+
+    assert m.layers == []
+    assert m.map_style["layers"][0]["type"] == "color-relief"
+
+    html = m.render()
+    assert "color-relief-color" in html
+    assert "terrain-tiles" in html
+    assert "interpolate" in html

--- a/tests/test_examples/test_add_a_hillshade_layer.py
+++ b/tests/test_examples/test_add_a_hillshade_layer.py
@@ -1,0 +1,40 @@
+"""Test for add-a-hillshade-layer MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+HILLSHADE_SOURCE = {
+    "type": "raster-dem",
+    "url": "https://demotiles.maplibre.org/terrain-tiles/tiles.json",
+    "tileSize": 512,
+}
+
+
+def test_add_a_hillshade_layer():
+    """Render hillshade styling with paint/layout options."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[11.39, 47.27],
+        zoom=12,
+    )
+    m.add_source("hillshadeSource", HILLSHADE_SOURCE)
+
+    hillshade_layer = layers.HillshadeLayer(
+        id="hillshade",
+        source="hillshadeSource",
+        layout={"visibility": "visible"},
+        paint={
+            "hillshade-shadow-color": "#473B24",
+            "hillshade-exaggeration": 0.5,
+        },
+    )
+    m.add_layer(hillshade_layer.to_dict())
+
+    assert len(m.layers) == 1
+    assert m.layers[0]["definition"]["type"] == "hillshade"
+
+    html = m.render()
+    assert "hillshade-shadow-color" in html
+    assert "hillshade-exaggeration" in html
+    assert "terrain-tiles" in html

--- a/tests/test_examples/test_add_a_multidirectional_hillshade_layer.py
+++ b/tests/test_examples/test_add_a_multidirectional_hillshade_layer.py
@@ -1,0 +1,38 @@
+"""Test for add-a-multidirectional-hillshade-layer MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+HILLSHADE_MULTIDIR_SOURCE = {
+    "type": "raster-dem",
+    "url": "https://demotiles.maplibre.org/terrain-tiles/tiles.json",
+    "tileSize": 512,
+}
+
+
+def test_add_a_multidirectional_hillshade_layer():
+    """Confirm multidirectional hillshade paint options render."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-113.57, 37.07],
+        zoom=11,
+    )
+    m.add_source("terrain-dem", HILLSHADE_MULTIDIR_SOURCE)
+
+    hillshade_layer = layers.HillshadeLayer(
+        id="multidirectional-hillshade",
+        source="terrain-dem",
+        paint={
+            "hillshade-exaggeration": 0.6,
+            "hillshade-illumination-direction": 335,
+            "hillshade-highlight-color": "#fff3b0",
+            "hillshade-shadow-color": "#3d2b1f",
+        },
+    )
+    m.add_layer(hillshade_layer.to_dict())
+
+    html = m.render()
+    assert "hillshade-illumination-direction" in html
+    assert "hillshade-highlight-color" in html
+    assert len(m.layers) == 1

--- a/tests/test_examples/test_add_a_new_layer_below_labels.py
+++ b/tests/test_examples/test_add_a_new_layer_below_labels.py
@@ -1,0 +1,51 @@
+"""Test for add-a-new-layer-below-labels MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+def test_add_a_new_layer_below_labels():
+    """Insert a symbol layer before the built-in label layer."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-77.0323, 38.9131],
+        zoom=13,
+    )
+
+    landmarks = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"name": "Lincoln Memorial"},
+                "geometry": {"type": "Point", "coordinates": [-77.050, 38.889]},
+            },
+            {
+                "type": "Feature",
+                "properties": {"name": "Washington Monument"},
+                "geometry": {"type": "Point", "coordinates": [-77.035, 38.8895]},
+            },
+        ],
+    }
+
+    m.add_source("landmarks", {"type": "geojson", "data": landmarks})
+
+    symbol_layer = layers.SymbolLayer(
+        id="landmarks",
+        source="landmarks",
+        layout={
+            "icon-image": "star-15",
+            "icon-allow-overlap": True,
+            "text-field": ["get", "name"],
+            "text-offset": [0, 1.25],
+        },
+        paint={"text-color": "#202", "text-halo-color": "#fff"},
+    )
+    m.add_layer(symbol_layer.to_dict(), before="waterway-label")
+
+    assert m.layers[0]["before"] == "waterway-label"
+
+    html = m.render()
+    assert "waterway-label" in html
+    assert "icon-image" in html
+    assert "text-field" in html

--- a/tests/test_examples/test_add_a_pattern_to_a_polygon.py
+++ b/tests/test_examples/test_add_a_pattern_to_a_polygon.py
@@ -1,0 +1,53 @@
+"""Test for add-a-pattern-to-a-polygon MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+def test_add_a_pattern_to_a_polygon():
+    """Recreate the pattern fill example using MapLibreum helpers."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        zoom=1,
+        center=[0, 0],
+    )
+
+    pattern_id = m.add_image(
+        "pattern-cat",
+        url=(
+            "https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/"
+            "Cat_silhouette.svg/64px-Cat_silhouette.svg.png"
+        ),
+    )
+
+    polygon = {
+        "type": "Feature",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [-30.0, -25.0],
+                    [-30.0, 35.0],
+                    [30.0, 35.0],
+                    [30.0, -25.0],
+                    [-30.0, -25.0],
+                ]
+            ],
+        },
+    }
+    m.add_source("pattern-source", {"type": "geojson", "data": polygon})
+
+    pattern_layer = layers.FillLayer(
+        id="pattern-layer",
+        source="pattern-source",
+        paint={"fill-pattern": pattern_id},
+    )
+    m.add_layer(pattern_layer.to_dict())
+
+    assert len(m.images) == 1
+    assert m.layers[0]["definition"]["paint"]["fill-pattern"] == pattern_id
+
+    html = m.render()
+    assert "fill-pattern" in html
+    assert "map.loadImage" in html
+    assert pattern_id in html

--- a/tests/test_examples/test_add_a_raster_tile_source.py
+++ b/tests/test_examples/test_add_a_raster_tile_source.py
@@ -1,0 +1,30 @@
+"""Test for add-a-raster-tile-source MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+def test_add_a_raster_tile_source():
+    """Add a raster tile source and ensure paint/layout survive."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-122.447303, 37.753574],
+        zoom=11,
+    )
+
+    raster_source = {
+        "type": "raster",
+        "tiles": [
+            "https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png"
+        ],
+        "tileSize": 256,
+    }
+    m.add_source("terrain-tiles", raster_source)
+
+    raster_layer = layers.RasterLayer(id="terrain-tiles", source="terrain-tiles")
+    m.add_layer(raster_layer.to_dict())
+
+    html = m.render()
+    assert '"type": "raster"' in html
+    assert "terrain" in html
+    assert len(m.layers) == 1

--- a/tests/test_examples/test_add_a_vector_tile_source.py
+++ b/tests/test_examples/test_add_a_vector_tile_source.py
@@ -1,0 +1,36 @@
+"""Test for add-a-vector-tile-source MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+def test_add_a_vector_tile_source():
+    """Attach a vector tile source and style it with a line layer."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-77.0323, 38.9131],
+        zoom=12,
+    )
+
+    vector_source = {
+        "type": "vector",
+        "tiles": ["https://demotiles.maplibre.org/tiles/{z}/{x}/{y}.pbf"],
+        "minzoom": 0,
+        "maxzoom": 14,
+    }
+    m.add_source("custom-vector", vector_source)
+
+    vector_layer = layers.LineLayer(
+        id="vector-rivers",
+        source="custom-vector",
+        source_layer="waterway",
+        layout={"line-join": "round", "line-cap": "round"},
+        paint={"line-color": "#ff69b4", "line-width": 1.2},
+    )
+    m.add_layer(vector_layer.to_dict())
+
+    html = m.render()
+    assert '"type": "vector"' in html
+    assert "ff69b4" in html
+    assert "tiles" in html
+    assert len(m.layers) == 1

--- a/tests/test_examples/test_add_contour_lines.py
+++ b/tests/test_examples/test_add_contour_lines.py
@@ -1,0 +1,85 @@
+from maplibreum import Map, layers
+
+
+def test_add_contour_lines():
+    """Ensure multi-layer contour styling is preserved in the rendered HTML."""
+
+    style = {
+        "version": 8,
+        "glyphs": "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
+        "sources": {
+            "hillshadeSource": {
+                "type": "raster-dem",
+                "tiles": [
+                    "https://demotiles.maplibre.org/terrain-tiles/{z}/{x}/{y}.png"
+                ],
+                "tileSize": 512,
+                "maxzoom": 12,
+            },
+            "contourSourceFeet": {
+                "type": "vector",
+                "tiles": [
+                    "https://demotiles.maplibre.org/contours/{z}/{x}/{y}.mvt"
+                ],
+                "maxzoom": 15,
+            },
+        },
+        "layers": [
+            layers.HillshadeLayer(
+                id="hills",
+                source="hillshadeSource",
+                layout={"visibility": "visible"},
+                paint={"hillshade-exaggeration": 0.25},
+            ).to_dict(),
+            layers.LineLayer(
+                id="contours",
+                source="contourSourceFeet",
+                source_layer="contours",
+                paint={
+                    "line-opacity": 0.5,
+                    "line-width": [
+                        "match",
+                        ["get", "level"],
+                        1,
+                        1,
+                        0.5,
+                    ],
+                },
+            ).to_dict(),
+            layers.SymbolLayer(
+                id="contour-text",
+                source="contourSourceFeet",
+                source_layer="contours",
+                filter=[">", ["get", "level"], 0],
+                paint={
+                    "text-halo-color": "white",
+                    "text-halo-width": 1,
+                },
+                layout={
+                    "symbol-placement": "line",
+                    "text-size": 10,
+                    "text-field": [
+                        "concat",
+                        ["number-format", ["get", "ele"], {}],
+                        "'",
+                    ],
+                    "text-font": ["Noto Sans Bold"],
+                },
+            ).to_dict(),
+        ],
+    }
+
+    m = Map(
+        map_style=style,
+        center=[11.3229, 47.2738],
+        zoom=13,
+        map_options={"hash": True},
+    )
+
+    html = m.render()
+
+    assert m.layers == []
+    assert "contourSourceFeet" in html
+    assert "hillshade-exaggeration" in html
+    assert "line-width" in html and "match" in html
+    assert "text-field" in html and "number-format" in html

--- a/tests/test_examples/test_change_building_color_based_on_zoom_level.py
+++ b/tests/test_examples/test_change_building_color_based_on_zoom_level.py
@@ -1,0 +1,59 @@
+"""Test for change-building-color-based-on-zoom-level MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+def test_change_building_color_based_on_zoom_level():
+    """Use zoom-based expressions to tint building extrusions."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-73.985664, 40.748514],
+        zoom=15,
+    )
+
+    building_layer = layers.FillExtrusionLayer(
+        id="3d-buildings",
+        source="composite",
+        source_layer="building",
+        minzoom=15,
+        paint={
+            "fill-extrusion-color": [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                15,
+                "#aaa",
+                16,
+                "#f08",
+                17,
+                "#ffb703",
+            ],
+            "fill-extrusion-height": [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                15,
+                0,
+                17,
+                ["get", "render_height"],
+            ],
+            "fill-extrusion-base": [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                15,
+                0,
+                17,
+                ["get", "render_min_height"],
+            ],
+            "fill-extrusion-opacity": 0.8,
+        },
+    )
+    m.add_layer(building_layer.to_dict(), before="waterway-label")
+
+    html = m.render()
+    assert "fill-extrusion-color" in html
+    assert '"zoom"' in html
+    assert "render_height" in html
+    assert len(m.layers) == 1

--- a/tests/test_examples/test_create_a_gradient_line_using_an_expression.py
+++ b/tests/test_examples/test_create_a_gradient_line_using_an_expression.py
@@ -1,0 +1,61 @@
+"""Test for create-a-gradient-line-using-an-expression MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+LINE_COORDS = [
+    [-122.48369693756104, 37.83381888486939],
+    [-122.48348236083984, 37.83317489144141],
+    [-122.48339653015138, 37.83270036637107],
+    [-122.48356819152832, 37.832056363179625],
+    [-122.48404026031496, 37.83114119107971],
+    [-122.48404026031496, 37.83049717427869],
+]
+
+
+def test_create_a_gradient_line_using_an_expression():
+    """Verify line-gradient expressions and line metrics."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-122.48369693756104, 37.83381888486939],
+        zoom=14,
+    )
+
+    source_definition = {
+        "type": "geojson",
+        "lineMetrics": True,
+        "data": {
+            "type": "Feature",
+            "geometry": {"type": "LineString", "coordinates": LINE_COORDS},
+        },
+    }
+    m.add_source("line", source_definition)
+
+    gradient_layer = layers.LineLayer(
+        id="gradient-line",
+        source="line",
+        layout={"line-cap": "round", "line-join": "round"},
+        paint={
+            "line-width": 14,
+            "line-color": "red",
+            "line-gradient": [
+                "interpolate",
+                ["linear"],
+                ["line-progress"],
+                0,
+                "blue",
+                0.5,
+                "lime",
+                1,
+                "red",
+            ],
+        },
+    )
+    m.add_layer(gradient_layer.to_dict())
+
+    html = m.render()
+    assert "line-gradient" in html
+    assert "line-progress" in html
+    assert "lineMetrics" in html
+    assert len(m.layers) == 1

--- a/tests/test_examples/test_display_a_globe_with_a_fill_extrusion_layer.py
+++ b/tests/test_examples/test_display_a_globe_with_a_fill_extrusion_layer.py
@@ -1,0 +1,71 @@
+"""Test for display-a-globe-with-a-fill-extrusion-layer MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+def test_display_a_globe_with_a_fill_extrusion_layer():
+    """Confirm globe projection and extrusion paint appear in HTML."""
+
+    m = Map(
+        title="Globe extrusion",
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[0, 0],
+        zoom=1.2,
+        map_options={"projection": "globe"},
+    )
+
+    features = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"height": 150000, "color": "#ff0044"},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-120.0, 10.0],
+                            [120.0, 10.0],
+                            [120.0, -10.0],
+                            [-120.0, -10.0],
+                            [-120.0, 10.0],
+                        ]
+                    ],
+                },
+            },
+            {
+                "type": "Feature",
+                "properties": {"height": 450000, "color": "#22ff44"},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [10.0, 50.0],
+                            [20.0, 50.0],
+                            [20.0, 40.0],
+                            [10.0, 40.0],
+                            [10.0, 50.0],
+                        ]
+                    ],
+                },
+            },
+        ],
+    }
+
+    m.add_source("extrude-polygons", {"type": "geojson", "data": features})
+
+    extrusion_layer = layers.FillExtrusionLayer(
+        id="extrude-polygons",
+        source="extrude-polygons",
+        paint={
+            "fill-extrusion-color": ["get", "color"],
+            "fill-extrusion-height": ["get", "height"],
+            "fill-extrusion-opacity": 0.9,
+        },
+    )
+    m.add_layer(extrusion_layer.to_dict())
+
+    html = m.render()
+    assert '"projection": "globe"' in html
+    assert "fill-extrusion-color" in html
+    assert "fill-extrusion-height" in html

--- a/tests/test_examples/test_display_a_remote_svg_symbol.py
+++ b/tests/test_examples/test_display_a_remote_svg_symbol.py
@@ -1,0 +1,50 @@
+from maplibreum import Map, layers
+
+
+def test_display_a_remote_svg_symbol():
+    """Remote SVG icons should be loaded via map.loadImage before usage."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[0, 0],
+        zoom=1,
+    )
+
+    m.add_image(
+        "maplibre-logo",
+        url="https://maplibre.org/maplibre-gl-js/docs/assets/logo.svg",
+    )
+
+    m.add_source(
+        "point",
+        {
+            "type": "geojson",
+            "data": {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    }
+                ],
+            },
+        },
+    )
+
+    symbol_layer = layers.SymbolLayer(
+        id="svg-symbol",
+        source="point",
+        layout={
+            "icon-image": "maplibre-logo",
+            "icon-overlap": "always",
+            "text-overlap": "always",
+        },
+    )
+    m.add_layer(symbol_layer.to_dict())
+
+    html = m.render()
+
+    assert "map.loadImage" in html
+    assert "logo.svg" in html
+    assert "svg-symbol" in html
+    assert len(m.layers) == 1

--- a/tests/test_examples/test_filter_within_a_layer.py
+++ b/tests/test_examples/test_filter_within_a_layer.py
@@ -1,0 +1,39 @@
+from maplibreum import Map, layers
+
+
+def test_filter_within_a_layer():
+    """Verify circle layer filter expressions are serialized into the template."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-117, 32],
+        zoom=3,
+    )
+
+    m.add_source(
+        "earthquakes",
+        {
+            "type": "geojson",
+            "data": "https://maplibre.org/maplibre-gl-js/docs/assets/earthquakes.geojson",
+        },
+    )
+
+    circle_layer = layers.CircleLayer(
+        id="earthquakes",
+        source="earthquakes",
+        paint={"circle-color": "#ff0000"},
+        filter=[
+            "all",
+            [">", ["get", "mag"], 4],
+            [">=", ["get", "felt"], 10],
+        ],
+    )
+    m.add_layer(circle_layer.to_dict())
+
+    html = m.render()
+
+    assert "earthquakes.geojson" in html
+    assert "\"circle-color\": \"#ff0000\"" in html
+    assert "\"filter\": [\"all\"" in html
+    assert "\"get\", \"mag\"" in html
+    assert len(m.layers) == 1

--- a/tests/test_examples/test_style_lines_with_a_data_driven_property.py
+++ b/tests/test_examples/test_style_lines_with_a_data_driven_property.py
@@ -1,0 +1,55 @@
+"""Test for style-lines-with-a-data-driven-property MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+def test_style_lines_with_a_data_driven_property():
+    """Validate that get expressions survive rendering."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-122.48369693756104, 37.83381888486939],
+        zoom=14,
+    )
+
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"color": "#ff5500"},
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [
+                        [-122.48369693756104, 37.83381888486939],
+                        [-122.48348236083984, 37.83317489144141],
+                    ],
+                },
+            },
+            {
+                "type": "Feature",
+                "properties": {"color": "#33C9EB"},
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [
+                        [-122.48356819152832, 37.832056363179625],
+                        [-122.48404026031496, 37.83114119107971],
+                    ],
+                },
+            },
+        ],
+    }
+
+    m.add_source("colored-lines", {"type": "geojson", "data": geojson})
+
+    line_layer = layers.LineLayer(
+        id="colored-lines",
+        source="colored-lines",
+        paint={"line-width": 3, "line-color": ["get", "color"]},
+    )
+    m.add_layer(line_layer.to_dict())
+
+    html = m.render()
+    assert '["get", "color"]' in html
+    assert "colored-lines" in html
+    assert len(m.layers) == 1

--- a/tests/test_examples/test_visualize_population_density.py
+++ b/tests/test_examples/test_visualize_population_density.py
@@ -1,0 +1,97 @@
+"""Test for visualize-population-density MapLibre example."""
+
+from maplibreum import Map, layers
+
+
+def test_visualize_population_density():
+    """Ensure nested let/var expressions survive serialization."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-96.7970, 32.7767],
+        zoom=5,
+    )
+
+    counties = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"population": 2635516, "sq-km": 2357},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-97.1, 32.9],
+                            [-96.4, 32.9],
+                            [-96.4, 32.5],
+                            [-97.1, 32.5],
+                            [-97.1, 32.9],
+                        ]
+                    ],
+                },
+            },
+            {
+                "type": "Feature",
+                "properties": {"population": 1341075, "sq-km": 906},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-96.8, 32.5],
+                            [-96.2, 32.5],
+                            [-96.2, 32.1],
+                            [-96.8, 32.1],
+                            [-96.8, 32.5],
+                        ]
+                    ],
+                },
+            },
+        ],
+    }
+
+    m.add_source("population-density", {"type": "geojson", "data": counties})
+
+    fill_color = [
+        "let",
+        "density",
+        ["/", ["get", "population"], ["get", "sq-km"]],
+        [
+            "interpolate",
+            ["linear"],
+            ["zoom"],
+            5,
+            [
+                "interpolate",
+                ["linear"],
+                ["var", "density"],
+                274,
+                ["to-color", "#edf8e9"],
+                1551,
+                ["to-color", "#006d2c"],
+            ],
+            7,
+            [
+                "interpolate",
+                ["linear"],
+                ["var", "density"],
+                274,
+                ["to-color", "#eff3ff"],
+                1551,
+                ["to-color", "#08519c"],
+            ],
+        ],
+    ]
+
+    density_layer = layers.FillLayer(
+        id="population-density",
+        source="population-density",
+        paint={"fill-color": fill_color, "fill-opacity": 0.7},
+    )
+    m.add_layer(density_layer.to_dict())
+
+    html = m.render()
+    assert '"let"' in html
+    assert '"var"' in html
+    assert '"to-color"' in html
+    assert len(m.layers) == 1


### PR DESCRIPTION
## Summary
- allow `Map.add_control` to resolve string aliases, create default search/measure controls, and expose registered images to the template
- extend layer helper wrappers so paint/layout/filter metadata mirrors the MapLibre GL JS API
- add pytest coverage for contour lines, remote SVG symbols, and filter-within-a-layer while updating the roadmap and status once Phase 2 passes 20%

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d0916b60c8832f9fa290de954e917d