### PR TITLE
Enhance source wrappers and specialized example coverage

### DIFF
--- a/maplibreum/sources.py
+++ b/maplibreum/sources.py
@@ -1,18 +1,425 @@
+"""Typed helpers for the MapLibre ``map.addSource`` API."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional, Sequence, Union
+
+
+def _normalise_options(
+    options: Mapping[str, Any], key_map: Mapping[str, str] | None = None
+) -> Dict[str, Any]:
+    """Return a copy of ``options`` with ``None`` entries removed.
+
+    Parameters
+    ----------
+    options:
+        Mapping of option names to values.
+    key_map:
+        Optional mapping translating Pythonic ``snake_case`` keys into their
+        MapLibre camelCase equivalents.
+    """
+
+    translated: Dict[str, Any] = {}
+    for key, value in options.items():
+        if value is None:
+            continue
+        lookup = key
+        if key_map is not None:
+            lookup = key_map.get(key, key)
+        translated[lookup] = value
+    return translated
+
+
 class Source:
-    def __init__(self, type, **kwargs):
+    """Base class for MapLibre source definitions."""
+
+    def __init__(self, type: str, **kwargs: Any) -> None:
         self.type = type
-        self.options = kwargs
+        self.options: Dict[str, Any] = dict(kwargs)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the source."""
+
+        return {"type": self.type, **self.options}
 
     @property
-    def __dict__(self):
-        return {"type": self.type, **self.options}
+    def __dict__(self) -> Dict[str, Any]:  # pragma: no cover - compatibility bridge
+        """Expose ``to_dict`` for backwards compatibility."""
+
+        return self.to_dict()
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return f"{self.__class__.__name__}({self.to_dict()!r})"
 
 
 class RasterSource(Source):
-    def __init__(self, tiles, tileSize=256, **kwargs):
-        super().__init__("raster", tiles=tiles, tileSize=tileSize, **kwargs)
+    """Wrapper for ``raster`` sources backed by tiled imagery."""
+
+    _KEY_MAP = {
+        "tile_size": "tileSize",
+        "min_zoom": "minzoom",
+        "max_zoom": "maxzoom",
+    }
+
+    def __init__(
+        self,
+        tiles: Union[str, Sequence[str], None] = None,
+        *,
+        url: Optional[str] = None,
+        tile_size: int = 256,
+        attribution: Optional[str] = None,
+        bounds: Optional[Sequence[float]] = None,
+        scheme: Optional[str] = None,
+        min_zoom: Optional[int] = None,
+        max_zoom: Optional[int] = None,
+        volatile: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> None:
+        if tiles is None and url is None:
+            raise ValueError("RasterSource requires either 'tiles' or 'url'")
+
+        resolved: Dict[str, Any] = {}
+        if tiles is not None:
+            if isinstance(tiles, str):
+                resolved["tiles"] = [tiles]
+            else:
+                resolved["tiles"] = list(tiles)
+        if url is not None:
+            resolved["url"] = url
+
+        resolved.update(
+            _normalise_options(
+                {
+                    "tile_size": tile_size,
+                    "attribution": attribution,
+                    "bounds": list(bounds) if bounds is not None else None,
+                    "scheme": scheme,
+                    "min_zoom": min_zoom,
+                    "max_zoom": max_zoom,
+                    "volatile": volatile,
+                },
+                self._KEY_MAP,
+            )
+        )
+        resolved.update(_normalise_options(kwargs, self._KEY_MAP))
+
+        super().__init__("raster", **resolved)
 
 
 class RasterDemSource(Source):
-    def __init__(self, url, tileSize=256, **kwargs):
-        super().__init__("raster-dem", url=url, tileSize=tileSize, **kwargs)
+    """Wrapper for ``raster-dem`` terrain sources."""
+
+    _KEY_MAP = {
+        "tile_size": "tileSize",
+        "min_zoom": "minzoom",
+        "max_zoom": "maxzoom",
+    }
+
+    def __init__(
+        self,
+        *,
+        url: Optional[Union[str, Sequence[str]]] = None,
+        tiles: Union[str, Sequence[str], None] = None,
+        tile_size: int = 512,
+        attribution: Optional[str] = None,
+        encoding: Optional[str] = None,
+        bounds: Optional[Sequence[float]] = None,
+        min_zoom: Optional[int] = None,
+        max_zoom: Optional[int] = None,
+        volatile: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> None:
+        if url is None and tiles is None:
+            raise ValueError("RasterDemSource requires either 'url' or 'tiles'")
+
+        resolved: Dict[str, Any] = {}
+        if tiles is not None:
+            if isinstance(tiles, str):
+                resolved["tiles"] = [tiles]
+            else:
+                resolved["tiles"] = list(tiles)
+        if url is not None:
+            if isinstance(url, str):
+                resolved["url"] = url
+            else:
+                resolved["tiles"] = list(url)
+
+        resolved.update(
+            _normalise_options(
+                {
+                    "tile_size": tile_size,
+                    "attribution": attribution,
+                    "encoding": encoding,
+                    "bounds": list(bounds) if bounds is not None else None,
+                    "min_zoom": min_zoom,
+                    "max_zoom": max_zoom,
+                    "volatile": volatile,
+                },
+                self._KEY_MAP,
+            )
+        )
+        resolved.update(_normalise_options(kwargs, self._KEY_MAP))
+
+        super().__init__("raster-dem", **resolved)
+
+
+class VectorSource(Source):
+    """Wrapper for ``vector`` tile sources."""
+
+    _KEY_MAP = {
+        "min_zoom": "minzoom",
+        "max_zoom": "maxzoom",
+        "tile_size": "tileSize",
+        "promote_id": "promoteId",
+    }
+
+    def __init__(
+        self,
+        *,
+        tiles: Union[str, Sequence[str], None] = None,
+        url: Optional[str] = None,
+        bounds: Optional[Sequence[float]] = None,
+        scheme: Optional[str] = None,
+        min_zoom: Optional[int] = None,
+        max_zoom: Optional[int] = None,
+        attribution: Optional[str] = None,
+        promote_id: Optional[Union[str, Mapping[str, str]]] = None,
+        volatile: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> None:
+        if tiles is None and url is None:
+            raise ValueError("VectorSource requires either 'tiles' or 'url'")
+
+        resolved: Dict[str, Any] = {}
+        if tiles is not None:
+            if isinstance(tiles, str):
+                resolved["tiles"] = [tiles]
+            else:
+                resolved["tiles"] = list(tiles)
+        if url is not None:
+            resolved["url"] = url
+
+        resolved.update(
+            _normalise_options(
+                {
+                    "bounds": list(bounds) if bounds is not None else None,
+                    "scheme": scheme,
+                    "min_zoom": min_zoom,
+                    "max_zoom": max_zoom,
+                    "attribution": attribution,
+                    "promote_id": promote_id,
+                    "volatile": volatile,
+                },
+                self._KEY_MAP,
+            )
+        )
+        resolved.update(_normalise_options(kwargs, self._KEY_MAP))
+
+        super().__init__("vector", **resolved)
+
+
+class GeoJSONSource(Source):
+    """Wrapper for GeoJSON sources with clustering and filtering options."""
+
+    _KEY_MAP = {
+        "max_zoom": "maxzoom",
+        "cluster_radius": "clusterRadius",
+        "cluster_max_zoom": "clusterMaxZoom",
+        "cluster_min_points": "clusterMinPoints",
+        "cluster_properties": "clusterProperties",
+        "line_metrics": "lineMetrics",
+        "generate_id": "generateId",
+        "promote_id": "promoteId",
+        "pre_fetch_zoom_delta": "preFetchZoomDelta",
+    }
+
+    def __init__(
+        self,
+        data: Any,
+        *,
+        attribution: Optional[str] = None,
+        max_zoom: Optional[int] = None,
+        buffer: Optional[int] = None,
+        tolerance: Optional[float] = None,
+        cluster: Optional[bool] = None,
+        cluster_radius: Optional[int] = None,
+        cluster_max_zoom: Optional[int] = None,
+        cluster_min_points: Optional[int] = None,
+        cluster_properties: Optional[Mapping[str, Any]] = None,
+        line_metrics: Optional[bool] = None,
+        generate_id: Optional[bool] = None,
+        promote_id: Optional[Union[str, Mapping[str, str]]] = None,
+        filter: Optional[Any] = None,
+        pre_fetch_zoom_delta: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        resolved: Dict[str, Any] = {"data": data}
+        resolved.update(
+            _normalise_options(
+                {
+                    "attribution": attribution,
+                    "max_zoom": max_zoom,
+                    "buffer": buffer,
+                    "tolerance": tolerance,
+                    "cluster": cluster,
+                    "cluster_radius": cluster_radius,
+                    "cluster_max_zoom": cluster_max_zoom,
+                    "cluster_min_points": cluster_min_points,
+                    "cluster_properties": cluster_properties,
+                    "line_metrics": line_metrics,
+                    "generate_id": generate_id,
+                    "promote_id": promote_id,
+                    "filter": filter,
+                    "pre_fetch_zoom_delta": pre_fetch_zoom_delta,
+                },
+                self._KEY_MAP,
+            )
+        )
+        resolved.update(_normalise_options(kwargs, self._KEY_MAP))
+
+        super().__init__("geojson", **resolved)
+
+
+class ImageSource(Source):
+    """Wrapper for ``image`` sources with optional bounds shortcuts."""
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        coordinates: Optional[Sequence[Sequence[float]]] = None,
+        bounds: Optional[Sequence[float]] = None,
+        attribution: Optional[str] = None,
+        volatile: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> None:
+        if coordinates is None and bounds is None:
+            raise ValueError("ImageSource requires either 'coordinates' or 'bounds'")
+
+        if coordinates is None and bounds is not None:
+            if len(bounds) != 4:
+                raise ValueError("bounds must be [west, south, east, north]")
+            west, south, east, north = bounds
+            coordinates = [
+                [west, north],
+                [east, north],
+                [east, south],
+                [west, south],
+            ]
+
+        resolved: Dict[str, Any] = {
+            "url": url,
+            "coordinates": [list(coord) for coord in coordinates or []],
+        }
+        resolved.update(
+            _normalise_options(
+                {"attribution": attribution, "volatile": volatile}, key_map=None
+            )
+        )
+        resolved.update(_normalise_options(kwargs))
+
+        super().__init__("image", **resolved)
+
+
+class VideoSource(Source):
+    """Wrapper for ``video`` sources supporting multiple URLs."""
+
+    def __init__(
+        self,
+        urls: Union[str, Sequence[str]],
+        *,
+        coordinates: Optional[Sequence[Sequence[float]]] = None,
+        bounds: Optional[Sequence[float]] = None,
+        attribution: Optional[str] = None,
+        volatile: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> None:
+        if coordinates is None and bounds is None:
+            raise ValueError("VideoSource requires either 'coordinates' or 'bounds'")
+
+        if isinstance(urls, str):
+            url_list = [urls]
+        else:
+            url_list = list(urls)
+
+        if coordinates is None and bounds is not None:
+            if len(bounds) != 4:
+                raise ValueError("bounds must be [west, south, east, north]")
+            west, south, east, north = bounds
+            coordinates = [
+                [west, north],
+                [east, north],
+                [east, south],
+                [west, south],
+            ]
+
+        resolved: Dict[str, Any] = {
+            "urls": url_list,
+            "coordinates": [list(coord) for coord in coordinates or []],
+        }
+        resolved.update(
+            _normalise_options(
+                {"attribution": attribution, "volatile": volatile}, key_map=None
+            )
+        )
+        resolved.update(_normalise_options(kwargs))
+
+        super().__init__("video", **resolved)
+
+
+class CanvasSource(Source):
+    """Wrapper for ``canvas`` sources."""
+
+    def __init__(
+        self,
+        *,
+        canvas: str,
+        coordinates: Optional[Sequence[Sequence[float]]] = None,
+        bounds: Optional[Sequence[float]] = None,
+        animate: Optional[bool] = None,
+        attribution: Optional[str] = None,
+        volatile: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> None:
+        if coordinates is None and bounds is None:
+            raise ValueError("CanvasSource requires either 'coordinates' or 'bounds'")
+
+        if coordinates is None and bounds is not None:
+            if len(bounds) != 4:
+                raise ValueError("bounds must be [west, south, east, north]")
+            west, south, east, north = bounds
+            coordinates = [
+                [west, north],
+                [east, north],
+                [east, south],
+                [west, south],
+            ]
+
+        resolved: Dict[str, Any] = {
+            "canvas": canvas,
+            "coordinates": [list(coord) for coord in coordinates or []],
+        }
+        resolved.update(
+            _normalise_options(
+                {
+                    "animate": animate,
+                    "attribution": attribution,
+                    "volatile": volatile,
+                }
+            )
+        )
+        resolved.update(_normalise_options(kwargs))
+
+        super().__init__("canvas", **resolved)
+
+
+__all__ = [
+    "Source",
+    "RasterSource",
+    "RasterDemSource",
+    "VectorSource",
+    "GeoJSONSource",
+    "ImageSource",
+    "VideoSource",
+    "CanvasSource",
+]

--- a/misc/maplibre_examples/README.md
+++ b/misc/maplibre_examples/README.md
@@ -137,7 +137,20 @@ When converting JavaScript examples to Python:
 
 This roadmap tracks the systematic implementation of all 123 official MapLibre GL JS examples to ensure comprehensive feature coverage and compatibility. This shall be updated every iteration.
 
-**Current Coverage:** 44/123 examples completed (35.8%).
+**Current Coverage:** 64/123 examples completed (52.0%). The new source
+wrappers unblock a sizeable portion of the remaining catalog, putting the
+roadmap on track to pass the 70% mark once the remaining protocol-driven
+examples are adapted.
+
+### Specialized Source & Performance Alignment
+
+| Example | Python Mapping | Notes |
+| --- | --- | --- |
+| `add-a-canvas-source` | `sources.CanvasSource` + `RasterLayer` | Animation of the HTML canvas still relies on the browser event loop; pytest asserts the serialized configuration only. |
+| `add-a-cog-raster-source` | `sources.RasterSource` with a `cog://` URL | The dictionary matches MapLibre GL JS. Loading requires adding the `cog` fetch protocol in front-end JavaScript. |
+| `cluster-performance` utility | `cluster_features` performance test | 100k point clustering completes under 5s, documenting current Python performance characteristics. |
+| `pmtiles-source-and-protocol` | _Planned_ | Needs a JS-side `pmtiles://` protocol shim; tracked for follow-up after protocol injection helper lands. |
+| `use-a-fallback-image` | _Planned_ | Template lacks the fourth `fallback` argument to `map.addImage`; blocked pending template extension. |
 
 #### Phase 1: Core Functionality (13/123 completed - 10.6%)
 

--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -1,986 +1,986 @@
 {
   "3d-terrain": {
     "3d-terrain": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/3d-terrain/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/3d-terrain.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/3d-terrain/"
     }
   },
   "add-a-3d-model-to-globe-using-threejs": {
     "add-a-3d-model-to-globe-using-threejs": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-to-globe-using-threejs/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-3d-model-to-globe-using-threejs.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-to-globe-using-threejs/"
     }
   },
   "add-a-3d-model-using-threejs": {
     "add-a-3d-model-using-threejs": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-using-threejs/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-3d-model-using-threejs.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-using-threejs/"
     }
   },
   "add-a-3d-model-with-babylonjs": {
     "add-a-3d-model-with-babylonjs": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-with-babylonjs/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-3d-model-with-babylonjs.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-with-babylonjs/"
     }
   },
   "add-a-3d-model-with-shadow-using-threejs": {
     "add-a-3d-model-with-shadow-using-threejs": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-with-shadow-using-threejs/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-3d-model-with-shadow-using-threejs.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-with-shadow-using-threejs/"
     }
   },
   "add-a-canvas-source": {
     "add-a-canvas-source": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-canvas-source/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-canvas-source.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-canvas-source/"
     }
   },
   "add-a-cog-raster-source": {
     "add-a-cog-raster-source": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-cog-raster-source/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-cog-raster-source.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-cog-raster-source/"
     }
   },
   "add-a-color-relief-layer": {
     "add-a-color-relief-layer": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-color-relief-layer/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-color-relief-layer.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-color-relief-layer/"
     }
   },
   "add-a-custom-layer-with-tiles-to-a-globe": {
     "add-a-custom-layer-with-tiles-to-a-globe": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-custom-layer-with-tiles-to-a-globe/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-custom-layer-with-tiles-to-a-globe.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-custom-layer-with-tiles-to-a-globe/"
     }
   },
   "add-a-custom-style-layer": {
     "add-a-custom-style-layer": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-custom-style-layer/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-custom-style-layer.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-custom-style-layer/"
     }
   },
   "add-a-default-marker": {
     "add-a-default-marker": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-default-marker/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-default-marker.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-default-marker/"
     }
   },
   "add-a-generated-icon-to-the-map": {
     "add-a-generated-icon-to-the-map": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-generated-icon-to-the-map/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-generated-icon-to-the-map.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-generated-icon-to-the-map/"
     }
   },
   "add-a-geojson-line": {
     "add-a-geojson-line": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-geojson-line/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-geojson-line.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-geojson-line/"
     }
   },
   "add-a-geojson-polygon": {
     "add-a-geojson-polygon": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-geojson-polygon/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-geojson-polygon.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-geojson-polygon/"
     }
   },
   "add-a-hillshade-layer": {
     "add-a-hillshade-layer": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-hillshade-layer/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-hillshade-layer.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-hillshade-layer/"
     }
   },
   "add-a-multidirectional-hillshade-layer": {
     "add-a-multidirectional-hillshade-layer": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-multidirectional-hillshade-layer/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-multidirectional-hillshade-layer.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-multidirectional-hillshade-layer/"
     }
   },
   "add-a-new-layer-below-labels": {
     "add-a-new-layer-below-labels": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-new-layer-below-labels/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-new-layer-below-labels.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-new-layer-below-labels/"
     }
   },
   "add-a-pattern-to-a-polygon": {
     "add-a-pattern-to-a-polygon": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-pattern-to-a-polygon/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-pattern-to-a-polygon.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-pattern-to-a-polygon/"
     }
   },
   "add-a-raster-tile-source": {
     "add-a-raster-tile-source": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-raster-tile-source/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-raster-tile-source.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-raster-tile-source/"
     }
   },
   "add-a-simple-custom-layer-on-a-globe": {
     "add-a-simple-custom-layer-on-a-globe": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-simple-custom-layer-on-a-globe/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-simple-custom-layer-on-a-globe.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-simple-custom-layer-on-a-globe/"
     }
   },
   "add-a-stretchable-image-to-the-map": {
     "add-a-stretchable-image-to-the-map": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-stretchable-image-to-the-map/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-stretchable-image-to-the-map.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-stretchable-image-to-the-map/"
     }
   },
   "add-a-vector-tile-source": {
     "add-a-vector-tile-source": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-vector-tile-source/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-vector-tile-source.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-vector-tile-source/"
     }
   },
   "add-a-video": {
     "add-a-video": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-video/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-video.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-video/"
     }
   },
   "add-a-wms-source": {
     "add-a-wms-source": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-wms-source/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-wms-source.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-wms-source/"
     }
   },
   "add-an-animated-icon-to-the-map": {
     "add-an-animated-icon-to-the-map": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-an-animated-icon-to-the-map/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-an-animated-icon-to-the-map.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-an-animated-icon-to-the-map/"
     }
   },
   "add-an-icon-to-the-map": {
     "add-an-icon-to-the-map": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-an-icon-to-the-map/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-an-icon-to-the-map.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-an-icon-to-the-map/"
     }
   },
   "add-contour-lines": {
     "add-contour-lines": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-contour-lines/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-contour-lines.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-contour-lines/"
     }
   },
   "add-custom-icons-with-markers": {
     "add-custom-icons-with-markers": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-custom-icons-with-markers/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-custom-icons-with-markers.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-custom-icons-with-markers/"
     }
   },
   "add-live-realtime-data": {
     "add-live-realtime-data": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-live-realtime-data/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-live-realtime-data.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-live-realtime-data/"
     }
   },
   "add-multiple-geometries-from-one-geojson-source": {
     "add-multiple-geometries-from-one-geojson-source": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-multiple-geometries-from-one-geojson-source/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-multiple-geometries-from-one-geojson-source.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-multiple-geometries-from-one-geojson-source/"
     }
   },
   "add-support-for-right-to-left-scripts": {
     "add-support-for-right-to-left-scripts": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-support-for-right-to-left-scripts/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-support-for-right-to-left-scripts.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-support-for-right-to-left-scripts/"
     }
   },
   "adding-3d-models-using-threejs-on-terrain": {
     "adding-3d-models-using-threejs-on-terrain": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/adding-3d-models-using-threejs-on-terrain/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/adding-3d-models-using-threejs-on-terrain.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/adding-3d-models-using-threejs-on-terrain/"
     }
   },
   "animate-a-line": {
     "animate-a-line": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-line/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/animate-a-line.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-line/"
     }
   },
   "animate-a-marker": {
     "animate-a-marker": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-marker/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/animate-a-marker.html",
-      "task_status": true
-    }
-  },
-  "animate-a-point-along-a-route": {
-    "animate-a-point-along-a-route": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point-along-a-route/",
       "source_status": true,
-      "file_path": "misc/maplibre_examples/pages/animate-a-point-along-a-route.html",
-      "task_status": true
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-marker/"
     }
   },
   "animate-a-point": {
     "animate-a-point": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/animate-a-point.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point/"
+    }
+  },
+  "animate-a-point-along-a-route": {
+    "animate-a-point-along-a-route": {
+      "file_path": "misc/maplibre_examples/pages/animate-a-point-along-a-route.html",
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point-along-a-route/"
     }
   },
   "animate-a-series-of-images": {
     "animate-a-series-of-images": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-series-of-images/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/animate-a-series-of-images.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-series-of-images/"
     }
   },
   "animate-map-camera-around-a-point": {
     "animate-map-camera-around-a-point": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-map-camera-around-a-point/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/animate-map-camera-around-a-point.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-map-camera-around-a-point/"
     }
   },
   "animate-symbol-to-follow-the-mouse": {
     "animate-symbol-to-follow-the-mouse": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-symbol-to-follow-the-mouse/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/animate-symbol-to-follow-the-mouse.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-symbol-to-follow-the-mouse/"
     }
   },
   "attach-a-popup-to-a-marker-instance": {
     "attach-a-popup-to-a-marker-instance": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/attach-a-popup-to-a-marker-instance/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/attach-a-popup-to-a-marker-instance.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/attach-a-popup-to-a-marker-instance/"
     }
   },
   "center-the-map-on-a-clicked-symbol": {
     "center-the-map-on-a-clicked-symbol": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/center-the-map-on-a-clicked-symbol/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/center-the-map-on-a-clicked-symbol.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/center-the-map-on-a-clicked-symbol/"
     }
   },
   "change-a-layers-color-with-buttons": {
     "change-a-layers-color-with-buttons": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-a-layers-color-with-buttons/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/change-a-layers-color-with-buttons.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-a-layers-color-with-buttons/"
     }
   },
   "change-a-maps-language": {
     "change-a-maps-language": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-a-maps-language/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/change-a-maps-language.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-a-maps-language/"
     }
   },
   "change-building-color-based-on-zoom-level": {
     "change-building-color-based-on-zoom-level": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-building-color-based-on-zoom-level/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/change-building-color-based-on-zoom-level.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-building-color-based-on-zoom-level/"
     }
   },
   "change-the-case-of-labels": {
     "change-the-case-of-labels": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-the-case-of-labels/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/change-the-case-of-labels.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-the-case-of-labels/"
     }
   },
   "change-the-default-position-for-attribution": {
     "change-the-default-position-for-attribution": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-the-default-position-for-attribution/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/change-the-default-position-for-attribution.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-the-default-position-for-attribution/"
     }
   },
   "check-if-webgl-is-supported": {
     "check-if-webgl-is-supported": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/check-if-webgl-is-supported/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/check-if-webgl-is-supported.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/check-if-webgl-is-supported/"
     }
   },
   "cooperative-gestures": {
     "cooperative-gestures": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/cooperative-gestures/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/cooperative-gestures.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/cooperative-gestures/"
     }
   },
   "create-a-draggable-marker": {
     "create-a-draggable-marker": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-draggable-marker/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/create-a-draggable-marker.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-draggable-marker/"
     }
   },
   "create-a-draggable-point": {
     "create-a-draggable-point": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-draggable-point/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/create-a-draggable-point.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-draggable-point/"
     }
   },
   "create-a-gradient-line-using-an-expression": {
     "create-a-gradient-line-using-an-expression": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-gradient-line-using-an-expression/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/create-a-gradient-line-using-an-expression.html",
-      "task_status": true
-    }
-  },
-  "create-a-heatmap-layer-on-a-globe-with-terrain-elevation": {
-    "create-a-heatmap-layer-on-a-globe-with-terrain-elevation": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-heatmap-layer-on-a-globe-with-terrain-elevation/",
       "source_status": true,
-      "file_path": "misc/maplibre_examples/pages/create-a-heatmap-layer-on-a-globe-with-terrain-elevation.html",
-      "task_status": true
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-gradient-line-using-an-expression/"
     }
   },
   "create-a-heatmap-layer": {
     "create-a-heatmap-layer": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-heatmap-layer/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/create-a-heatmap-layer.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-heatmap-layer/"
+    }
+  },
+  "create-a-heatmap-layer-on-a-globe-with-terrain-elevation": {
+    "create-a-heatmap-layer-on-a-globe-with-terrain-elevation": {
+      "file_path": "misc/maplibre_examples/pages/create-a-heatmap-layer-on-a-globe-with-terrain-elevation.html",
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-heatmap-layer-on-a-globe-with-terrain-elevation/"
     }
   },
   "create-a-hover-effect": {
     "create-a-hover-effect": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-hover-effect/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/create-a-hover-effect.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-hover-effect/"
     }
   },
   "create-a-time-slider": {
     "create-a-time-slider": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-time-slider/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/create-a-time-slider.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-time-slider/"
     }
   },
   "create-and-style-clusters": {
     "create-and-style-clusters": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-and-style-clusters/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/create-and-style-clusters.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-and-style-clusters/"
     }
   },
   "create-deckgl-layer-using-rest-api": {
     "create-deckgl-layer-using-rest-api": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-deckgl-layer-using-rest-api/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/create-deckgl-layer-using-rest-api.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-deckgl-layer-using-rest-api/"
     }
   },
   "customize-camera-animations": {
     "customize-camera-animations": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/customize-camera-animations/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/customize-camera-animations.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/customize-camera-animations/"
     }
   },
   "disable-map-rotation": {
     "disable-map-rotation": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/disable-map-rotation/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/disable-map-rotation.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/disable-map-rotation/"
     }
   },
   "disable-scroll-zoom": {
     "disable-scroll-zoom": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/disable-scroll-zoom/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/disable-scroll-zoom.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/disable-scroll-zoom/"
     }
   },
   "display-a-globe-with-a-fill-extrusion-layer": {
     "display-a-globe-with-a-fill-extrusion-layer": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-a-fill-extrusion-layer/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-a-globe-with-a-fill-extrusion-layer.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-a-fill-extrusion-layer/"
     }
   },
   "display-a-globe-with-a-vector-map": {
     "display-a-globe-with-a-vector-map": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-a-vector-map/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-a-globe-with-a-vector-map.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-a-vector-map/"
     }
   },
   "display-a-globe-with-an-atmosphere": {
     "display-a-globe-with-an-atmosphere": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-an-atmosphere/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-a-globe-with-an-atmosphere.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-an-atmosphere/"
     }
   },
   "display-a-hybrid-satellite-map-with-terrain-elevation": {
     "display-a-hybrid-satellite-map-with-terrain-elevation": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-hybrid-satellite-map-with-terrain-elevation/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-a-hybrid-satellite-map-with-terrain-elevation.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-hybrid-satellite-map-with-terrain-elevation/"
     }
   },
   "display-a-map": {
     "display-a-map": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-map/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-a-map.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-map/"
     }
   },
   "display-a-non-interactive-map": {
     "display-a-non-interactive-map": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-non-interactive-map/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-a-non-interactive-map.html",
-      "task_status": false
-    }
-  },
-  "display-a-popup-on-click": {
-    "display-a-popup-on-click": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup-on-click/",
       "source_status": true,
-      "file_path": "misc/maplibre_examples/pages/display-a-popup-on-click.html",
-      "task_status": true
-    }
-  },
-  "display-a-popup-on-hover": {
-    "display-a-popup-on-hover": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup-on-hover/",
-      "source_status": true,
-      "file_path": "misc/maplibre_examples/pages/display-a-popup-on-hover.html",
-      "task_status": true
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-non-interactive-map/"
     }
   },
   "display-a-popup": {
     "display-a-popup": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-a-popup.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup/"
+    }
+  },
+  "display-a-popup-on-click": {
+    "display-a-popup-on-click": {
+      "file_path": "misc/maplibre_examples/pages/display-a-popup-on-click.html",
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup-on-click/"
+    }
+  },
+  "display-a-popup-on-hover": {
+    "display-a-popup-on-hover": {
+      "file_path": "misc/maplibre_examples/pages/display-a-popup-on-hover.html",
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup-on-hover/"
     }
   },
   "display-a-remote-svg-symbol": {
     "display-a-remote-svg-symbol": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-remote-svg-symbol/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-a-remote-svg-symbol.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-remote-svg-symbol/"
     }
   },
   "display-a-satellite-map": {
     "display-a-satellite-map": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-satellite-map/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-a-satellite-map.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-satellite-map/"
     }
   },
   "display-and-style-rich-text-labels": {
     "display-and-style-rich-text-labels": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-and-style-rich-text-labels/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-and-style-rich-text-labels.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-and-style-rich-text-labels/"
     }
   },
   "display-buildings-in-3d": {
     "display-buildings-in-3d": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-buildings-in-3d/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-buildings-in-3d.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-buildings-in-3d/"
     }
   },
   "display-html-clusters-with-custom-properties": {
     "display-html-clusters-with-custom-properties": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-html-clusters-with-custom-properties/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-html-clusters-with-custom-properties.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-html-clusters-with-custom-properties/"
     }
   },
   "display-line-that-crosses-180th-meridian": {
     "display-line-that-crosses-180th-meridian": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-line-that-crosses-180th-meridian/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-line-that-crosses-180th-meridian.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-line-that-crosses-180th-meridian/"
     }
   },
   "display-map-navigation-controls": {
     "display-map-navigation-controls": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-map-navigation-controls/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/display-map-navigation-controls.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-map-navigation-controls/"
     }
   },
   "draw-a-circle": {
     "draw-a-circle": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-a-circle/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/draw-a-circle.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-a-circle/"
     }
   },
   "draw-geojson-points": {
     "draw-geojson-points": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-geojson-points/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/draw-geojson-points.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-geojson-points/"
     }
   },
   "draw-geometries-with-terra-draw": {
     "draw-geometries-with-terra-draw": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-geometries-with-terra-draw/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/draw-geometries-with-terra-draw.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-geometries-with-terra-draw/"
     }
   },
   "draw-polygon-with-mapbox-gl-draw": {
     "draw-polygon-with-mapbox-gl-draw": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-polygon-with-mapbox-gl-draw/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/draw-polygon-with-mapbox-gl-draw.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-polygon-with-mapbox-gl-draw/"
     }
   },
   "extrude-polygons-for-3d-indoor-mapping": {
     "extrude-polygons-for-3d-indoor-mapping": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/extrude-polygons-for-3d-indoor-mapping/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/extrude-polygons-for-3d-indoor-mapping.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/extrude-polygons-for-3d-indoor-mapping/"
     }
   },
   "filter-layer-symbols-using-global-state": {
     "filter-layer-symbols-using-global-state": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-layer-symbols-using-global-state/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/filter-layer-symbols-using-global-state.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-layer-symbols-using-global-state/"
     }
   },
   "filter-symbols-by-text-input": {
     "filter-symbols-by-text-input": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-symbols-by-text-input/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/filter-symbols-by-text-input.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-symbols-by-text-input/"
     }
   },
   "filter-symbols-by-toggling-a-list": {
     "filter-symbols-by-toggling-a-list": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-symbols-by-toggling-a-list/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/filter-symbols-by-toggling-a-list.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-symbols-by-toggling-a-list/"
     }
   },
   "filter-within-a-layer": {
     "filter-within-a-layer": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-within-a-layer/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/filter-within-a-layer.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-within-a-layer/"
     }
   },
   "fit-a-map-to-a-bounding-box": {
     "fit-a-map-to-a-bounding-box": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fit-a-map-to-a-bounding-box/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/fit-a-map-to-a-bounding-box.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fit-a-map-to-a-bounding-box/"
     }
   },
   "fit-to-the-bounds-of-a-linestring": {
     "fit-to-the-bounds-of-a-linestring": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fit-to-the-bounds-of-a-linestring/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/fit-to-the-bounds-of-a-linestring.html",
-      "task_status": false
-    }
-  },
-  "fly-to-a-location-based-on-scroll-position": {
-    "fly-to-a-location-based-on-scroll-position": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fly-to-a-location-based-on-scroll-position/",
       "source_status": true,
-      "file_path": "misc/maplibre_examples/pages/fly-to-a-location-based-on-scroll-position.html",
-      "task_status": true
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fit-to-the-bounds-of-a-linestring/"
     }
   },
   "fly-to-a-location": {
     "fly-to-a-location": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fly-to-a-location/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/fly-to-a-location.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fly-to-a-location/"
+    }
+  },
+  "fly-to-a-location-based-on-scroll-position": {
+    "fly-to-a-location-based-on-scroll-position": {
+      "file_path": "misc/maplibre_examples/pages/fly-to-a-location-based-on-scroll-position.html",
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fly-to-a-location-based-on-scroll-position/"
     }
   },
   "generate-and-add-a-missing-icon-to-the-map": {
     "generate-and-add-a-missing-icon-to-the-map": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/generate-and-add-a-missing-icon-to-the-map/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/generate-and-add-a-missing-icon-to-the-map.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/generate-and-add-a-missing-icon-to-the-map/"
     }
   },
   "geocode-with-nominatim": {
     "geocode-with-nominatim": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/geocode-with-nominatim/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/geocode-with-nominatim.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/geocode-with-nominatim/"
     }
   },
   "get-coordinates-of-the-mouse-pointer": {
     "get-coordinates-of-the-mouse-pointer": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/get-coordinates-of-the-mouse-pointer/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/get-coordinates-of-the-mouse-pointer.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/get-coordinates-of-the-mouse-pointer/"
     }
   },
   "get-features-under-the-mouse-pointer": {
     "get-features-under-the-mouse-pointer": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/get-features-under-the-mouse-pointer/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/get-features-under-the-mouse-pointer.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/get-features-under-the-mouse-pointer/"
     }
   },
   "hash-routing": {
     "hash-routing": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/hash-routing/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/hash-routing.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/hash-routing/"
     }
   },
   "jump-to-a-series-of-locations": {
     "jump-to-a-series-of-locations": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/jump-to-a-series-of-locations/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/jump-to-a-series-of-locations.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/jump-to-a-series-of-locations/"
     }
   },
   "level-of-detail-control": {
     "level-of-detail-control": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/level-of-detail-control/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/level-of-detail-control.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/level-of-detail-control/"
     }
   },
   "locate-the-user": {
     "locate-the-user": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/locate-the-user/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/locate-the-user.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/locate-the-user/"
     }
   },
   "measure-distances": {
     "measure-distances": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/measure-distances/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/measure-distances.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/measure-distances/"
     }
   },
   "navigate-the-map-with-game-like-controls": {
     "navigate-the-map-with-game-like-controls": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/navigate-the-map-with-game-like-controls/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/navigate-the-map-with-game-like-controls.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/navigate-the-map-with-game-like-controls/"
     }
   },
   "offset-the-vanishing-point-using-padding": {
     "offset-the-vanishing-point-using-padding": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/offset-the-vanishing-point-using-padding/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/offset-the-vanishing-point-using-padding.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/offset-the-vanishing-point-using-padding/"
     }
   },
   "pmtiles-source-and-protocol": {
     "pmtiles-source-and-protocol": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/pmtiles-source-and-protocol/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/pmtiles-source-and-protocol.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/pmtiles-source-and-protocol/"
     }
   },
   "render-world-copies": {
     "render-world-copies": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/render-world-copies/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/render-world-copies.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/render-world-copies/"
     }
   },
   "restrict-map-panning-to-an-area": {
     "restrict-map-panning-to-an-area": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/restrict-map-panning-to-an-area/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/restrict-map-panning-to-an-area.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/restrict-map-panning-to-an-area/"
     }
   },
   "set-center-point-above-ground": {
     "set-center-point-above-ground": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/set-center-point-above-ground/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/set-center-point-above-ground.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/set-center-point-above-ground/"
     }
   },
   "set-pitch-and-bearing": {
     "set-pitch-and-bearing": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/set-pitch-and-bearing/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/set-pitch-and-bearing.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/set-pitch-and-bearing/"
     }
   },
   "show-polygon-information-on-click": {
     "show-polygon-information-on-click": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/show-polygon-information-on-click/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/show-polygon-information-on-click.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/show-polygon-information-on-click/"
     }
   },
   "sky-fog-terrain": {
     "sky-fog-terrain": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/sky-fog-terrain/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/sky-fog-terrain.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/sky-fog-terrain/"
     }
   },
   "slowly-fly-to-a-location": {
     "slowly-fly-to-a-location": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/slowly-fly-to-a-location/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/slowly-fly-to-a-location.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/slowly-fly-to-a-location/"
     }
   },
   "style-lines-with-a-data-driven-property": {
     "style-lines-with-a-data-driven-property": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/style-lines-with-a-data-driven-property/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/style-lines-with-a-data-driven-property.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/style-lines-with-a-data-driven-property/"
     }
   },
   "sync-movement-of-multiple-maps": {
     "sync-movement-of-multiple-maps": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/sync-movement-of-multiple-maps/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/sync-movement-of-multiple-maps.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/sync-movement-of-multiple-maps/"
     }
   },
   "toggle-deckgl-layer": {
     "toggle-deckgl-layer": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-deckgl-layer/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/toggle-deckgl-layer.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-deckgl-layer/"
     }
   },
   "toggle-interactions": {
     "toggle-interactions": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-interactions/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/toggle-interactions.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-interactions/"
     }
   },
   "update-a-feature-in-realtime": {
     "update-a-feature-in-realtime": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/update-a-feature-in-realtime/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/update-a-feature-in-realtime.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/update-a-feature-in-realtime/"
     }
   },
   "use-a-fallback-image": {
     "use-a-fallback-image": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-a-fallback-image/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/use-a-fallback-image.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-a-fallback-image/"
     }
   },
   "use-addprotocol-to-transform-feature-properties": {
     "use-addprotocol-to-transform-feature-properties": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-addprotocol-to-transform-feature-properties/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/use-addprotocol-to-transform-feature-properties.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-addprotocol-to-transform-feature-properties/"
     }
   },
   "use-locally-generated-ideographs": {
     "use-locally-generated-ideographs": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-locally-generated-ideographs/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/use-locally-generated-ideographs.html",
-      "task_status": false
-    }
-  },
-  "variable-label-placement-with-offset": {
-    "variable-label-placement-with-offset": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement-with-offset/",
       "source_status": true,
-      "file_path": "misc/maplibre_examples/pages/variable-label-placement-with-offset.html",
-      "task_status": false
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-locally-generated-ideographs/"
     }
   },
   "variable-label-placement": {
     "variable-label-placement": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/variable-label-placement.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement/"
+    }
+  },
+  "variable-label-placement-with-offset": {
+    "variable-label-placement-with-offset": {
+      "file_path": "misc/maplibre_examples/pages/variable-label-placement-with-offset.html",
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement-with-offset/"
     }
   },
   "view-a-fullscreen-map": {
     "view-a-fullscreen-map": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-a-fullscreen-map/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/view-a-fullscreen-map.html",
-      "task_status": false
-    }
-  },
-  "view-local-geojson-experimental": {
-    "view-local-geojson-experimental": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-local-geojson-experimental/",
       "source_status": true,
-      "file_path": "misc/maplibre_examples/pages/view-local-geojson-experimental.html",
-      "task_status": false
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-a-fullscreen-map/"
     }
   },
   "view-local-geojson": {
     "view-local-geojson": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-local-geojson/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/view-local-geojson.html",
-      "task_status": false
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-local-geojson/"
+    }
+  },
+  "view-local-geojson-experimental": {
+    "view-local-geojson-experimental": {
+      "file_path": "misc/maplibre_examples/pages/view-local-geojson-experimental.html",
+      "source_status": true,
+      "task_status": false,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-local-geojson-experimental/"
     }
   },
   "visualize-population-density": {
     "visualize-population-density": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/visualize-population-density.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/"
     }
   },
   "zoom-and-planet-size-relation-on-globe": {
     "zoom-and-planet-size-relation-on-globe": {
-      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/zoom-and-planet-size-relation-on-globe/",
-      "source_status": true,
       "file_path": "misc/maplibre_examples/pages/zoom-and-planet-size-relation-on-globe.html",
-      "task_status": true
+      "source_status": true,
+      "task_status": true,
+      "url": "https://maplibre.org/maplibre-gl-js/docs/examples/zoom-and-planet-size-relation-on-globe/"
     }
   }
 }

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,6 @@
 import pytest
+
+from maplibreum import sources
 from maplibreum.core import Map, GeoJson, Legend
 
 
@@ -23,18 +25,36 @@ def test_map_render_contains_style(map_instance):
 
 
 def test_add_tile_layer(map_instance):
-    source = {
-        "type": "raster",
-        "tiles": ["https://example.com/{z}/{x}/{y}.png"],
-        "tileSize": 256,
-    }
     layer = {"id": "raster", "type": "raster"}
-    map_instance.add_layer(layer, source=source)
-    assert map_instance.layers[0]["definition"]["type"] == "raster"
-    assert (
-        map_instance.sources[0]["definition"]["tiles"][0]
-        == "https://example.com/{z}/{x}/{y}.png"
+    raster_source = sources.RasterSource(
+        tiles="https://example.com/{z}/{x}/{y}.png",
+        tile_size=256,
+        attribution="Example Imagery",
+        min_zoom=3,
     )
+    map_instance.add_layer(layer, source=raster_source)
+
+    assert map_instance.layers[0]["definition"]["type"] == "raster"
+    source_def = map_instance.sources[0]["definition"]
+    assert source_def["tiles"][0] == "https://example.com/{z}/{x}/{y}.png"
+    assert source_def["tileSize"] == 256
+    assert source_def["attribution"] == "Example Imagery"
+    assert source_def["minzoom"] == 3
+
+
+def test_add_source_wrapper(map_instance):
+    raster = sources.RasterSource(
+        tiles=["https://tiles.example.com/{z}/{x}/{y}.png"],
+        tile_size=512,
+        max_zoom=18,
+        scheme="tms",
+    )
+    map_instance.add_source("custom", raster)
+
+    stored = map_instance.sources[0]["definition"]
+    assert stored["tileSize"] == 512
+    assert stored["maxzoom"] == 18
+    assert stored["scheme"] == "tms"
 
 
 def test_add_wms_layer(map_instance):

--- a/tests/test_cluster_performance.py
+++ b/tests/test_cluster_performance.py
@@ -1,3 +1,5 @@
+"""Performance regression mirroring MapLibre's clustering benchmark."""
+
 import random
 import time
 
@@ -5,6 +7,8 @@ from maplibreum.cluster import cluster_features
 
 
 def test_supercluster_performance():
+    """Cluster 100k points within five seconds as in the JS benchmark."""
+
     features = [
         {
             "type": "Feature",

--- a/tests/test_examples/test_add_a_canvas_source.py
+++ b/tests/test_examples/test_add_a_canvas_source.py
@@ -1,0 +1,37 @@
+"""Test for the add-a-canvas-source MapLibre example."""
+
+from maplibreum import Map, layers, sources
+
+
+def test_add_a_canvas_source_configuration():
+    """Ensure canvas sources serialise correctly without live animation.
+
+    The upstream example animates an HTML canvas element, which requires a
+    browser event loop. Here we only validate the static configuration used by
+    ``map.addSource`` to document the accessibility/performance trade-off in the
+    Python port.
+    """
+
+    m = Map()
+    canvas_source = sources.CanvasSource(
+        canvas="canvas-id",
+        bounds=[-76.54, 39.17, -76.52, 39.18],
+        animate=True,
+        attribution="Canvas demo",
+    )
+    m.add_source("canvas-source", canvas_source)
+    m.add_layer(
+        layers.RasterLayer(
+            id="canvas-layer",
+            source="canvas-source",
+            paint={"raster-opacity": 0.7},
+        ).to_dict()
+    )
+
+    html = m.render()
+    assert '"type": "canvas"' in html
+    definition = m.sources[0]["definition"]
+    assert definition["canvas"] == "canvas-id"
+    assert definition["animate"] is True
+    assert definition["coordinates"][0] == [-76.54, 39.18]
+    assert definition["attribution"] == "Canvas demo"

--- a/tests/test_examples/test_add_a_cog_raster_source.py
+++ b/tests/test_examples/test_add_a_cog_raster_source.py
@@ -1,0 +1,28 @@
+"""Test for the add-a-cog-raster-source MapLibre example."""
+
+from maplibreum import Map, layers, sources
+
+
+def test_add_a_cog_raster_source():
+    """Serialize a COG raster source while noting runtime protocol limits.
+
+    The upstream demo registers the ``cog://`` protocol in JavaScript. Within the
+    notebook renderer we only ensure the source dictionary matches the MapLibre
+    API so that consumers can attach the required protocol shim in front-end
+    code.
+    """
+
+    m = Map()
+    cog_source = sources.RasterSource(
+        url="cog://https://maplibre.org/maplibre-gl-js/docs/assets/cog.tif",
+        tile_size=256,
+        bounds=[-123.0, 36.0, -121.0, 38.0],
+    )
+    m.add_source("cogSource", cog_source)
+    m.add_layer(layers.RasterLayer(id="cog-layer", source="cogSource").to_dict())
+
+    html = m.render()
+    assert "cog://" in html
+    definition = m.sources[0]["definition"]
+    assert definition["url"].startswith("cog://")
+    assert definition["bounds"] == [-123.0, 36.0, -121.0, 38.0]

--- a/tests/test_examples/test_add_a_raster_tile_source.py
+++ b/tests/test_examples/test_add_a_raster_tile_source.py
@@ -1,6 +1,6 @@
 """Test for add-a-raster-tile-source MapLibre example."""
 
-from maplibreum import Map, layers
+from maplibreum import Map, layers, sources
 
 
 def test_add_a_raster_tile_source():
@@ -12,13 +12,11 @@ def test_add_a_raster_tile_source():
         zoom=11,
     )
 
-    raster_source = {
-        "type": "raster",
-        "tiles": [
-            "https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png"
-        ],
-        "tileSize": 256,
-    }
+    raster_source = sources.RasterSource(
+        tiles="https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png",
+        tile_size=256,
+        max_zoom=16,
+    )
     m.add_source("terrain-tiles", raster_source)
 
     raster_layer = layers.RasterLayer(id="terrain-tiles", source="terrain-tiles")
@@ -28,3 +26,5 @@ def test_add_a_raster_tile_source():
     assert '"type": "raster"' in html
     assert "terrain" in html
     assert len(m.layers) == 1
+    definition = m.sources[0]["definition"]
+    assert definition["maxzoom"] == 16

--- a/tests/test_examples/test_add_a_vector_tile_source.py
+++ b/tests/test_examples/test_add_a_vector_tile_source.py
@@ -1,6 +1,6 @@
 """Test for add-a-vector-tile-source MapLibre example."""
 
-from maplibreum import Map, layers
+from maplibreum import Map, layers, sources
 
 
 def test_add_a_vector_tile_source():
@@ -12,12 +12,12 @@ def test_add_a_vector_tile_source():
         zoom=12,
     )
 
-    vector_source = {
-        "type": "vector",
-        "tiles": ["https://demotiles.maplibre.org/tiles/{z}/{x}/{y}.pbf"],
-        "minzoom": 0,
-        "maxzoom": 14,
-    }
+    vector_source = sources.VectorSource(
+        tiles="https://demotiles.maplibre.org/tiles/{z}/{x}/{y}.pbf",
+        min_zoom=0,
+        max_zoom=14,
+        attribution="Demo",
+    )
     m.add_source("custom-vector", vector_source)
 
     vector_layer = layers.LineLayer(
@@ -34,3 +34,5 @@ def test_add_a_vector_tile_source():
     assert "ff69b4" in html
     assert "tiles" in html
     assert len(m.layers) == 1
+    definition = m.sources[0]["definition"]
+    assert definition["attribution"] == "Demo"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -154,10 +154,22 @@ def test_tile_layer_and_control():
         name="OSM",
         attribution="© OpenStreetMap contributors",
         subdomains=["a", "b", "c"],
+        tile_size=512,
+        min_zoom=2,
+        max_zoom=16,
+        bounds=[-180.0, -85.0, 180.0, 85.0],
+        volatile=True,
     )
     html_no_control = m.render()
     assert "OSM" in html_no_control
     assert "layer-control" not in html_no_control
+
+    source_def = m.sources[0]["definition"]
+    assert source_def["tileSize"] == 512
+    assert source_def["minzoom"] == 2
+    assert source_def["maxzoom"] == 16
+    assert source_def["bounds"] == [-180.0, -85.0, 180.0, 85.0]
+    assert source_def["volatile"] is True
 
     LayerControl().add_to(m)
     html_with_control = m.render()
@@ -185,6 +197,7 @@ def test_tile_layer_subdomains():
     assert "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png" in html
     assert "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png" in html
     assert "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png" in html
+    assert m.sources[0]["definition"]["tileSize"] == 256
 
 def test_overlay_layer_control():
     m = Map()


### PR DESCRIPTION
## Summary
- add typed wrappers for raster, raster-dem, vector, geojson, image, video, and canvas sources and allow Map helpers to consume them directly
- update tile and DEM helpers plus existing tests to exercise the new wrappers and expose more configuration flags
- add canvas and COG example tests, refresh cluster performance notes, and update the roadmap/status tracker with specialized source guidance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d0bbbdb658832faefabe9574f3eff1