### PR TITLE
Ensure gallery tests run in CI and document roadmap workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+- [ ] Closes <!-- issue link -->
+- [ ] Includes documentation updates when needed
+
+## Testing Checklist
+
+- [ ] `pytest -k "not test_examples"`
+- [ ] `pytest tests/test_examples/ -v`
+- [ ] Focused example tests (list the exact `pytest` invocations or mark N/A):
+
+## MapLibre Examples Roadmap
+
+- [ ] Reviewed HTML parity for any touched examples against `misc/maplibre_examples/pages`
+- [ ] Updated `misc/maplibre_examples/status.json` for new or changed examples
+- [ ] Regenerated the progress snapshot using the helper commands in `misc/maplibre_examples/README.md` and committed the refreshed figures
+
+### Progress Snapshot
+
+| Metric | Value |
+| --- | --- |
+| Total examples tracked | <!-- e.g. 123 --> |
+| Examples implemented | <!-- e.g. 123 --> |
+| Coverage percentage | <!-- e.g. 100% --> |
+
+### Notes
+
+<!-- Add any additional context for reviewers here. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,46 @@ jobs:
         run: |
           pip install -e .
           pip install pytest
-      - name: Run tests
-        run: pytest
+      - name: Run core tests
+        run: pytest -k "not test_examples"
+      - name: Run MapLibre example tests
+        run: pytest tests/test_examples/ -v
+      - name: Run focused example tests (if any)
+        run: |
+          python - <<'PY'
+import pathlib
+import subprocess
+import sys
+
+tests_dir = pathlib.Path("tests") / "test_examples"
+if not tests_dir.exists():
+    print("No example tests directory found; skipping focused run.")
+    raise SystemExit(0)
+
+focused_candidates = []
+focus_dir = tests_dir / "focused"
+if focus_dir.exists():
+    focused_candidates.extend(sorted(focus_dir.glob("test_*.py")))
+
+for pattern in ("*focused*.py", "*focus*.py"):
+    focused_candidates.extend(sorted(tests_dir.glob(pattern)))
+
+unique_paths = []
+seen = set()
+for path in focused_candidates:
+    if not path.is_file():
+        continue
+    rel_path = path.as_posix()
+    if rel_path in seen:
+        continue
+    seen.add(rel_path)
+    unique_paths.append(rel_path)
+
+if not unique_paths:
+    print("No focused example tests detected; skipping.")
+    raise SystemExit(0)
+
+cmd = ["pytest", "-v", *unique_paths]
+print("Running focused example tests:", " ".join(cmd))
+raise SystemExit(subprocess.call(cmd))
+PY

--- a/README.md
+++ b/README.md
@@ -12,8 +12,39 @@ pip install maplibreum
 
 ```bash
 pip install -e .
-pytest
+pytest -k "not test_examples"
+pytest tests/test_examples/ -v
 ```
+
+### Contribution Workflow
+
+- Start from the existing gallery tests in `tests/test_examples/` when adding a new
+  MapLibre example. Files such as
+  `tests/test_examples/test_display_a_map.py` provide a concise template for
+  porting the upstream HTML/JavaScript into maplibreum assertions.
+- Exercise targeted examples locally with:
+
+  ```bash
+  pytest tests/test_examples/test_<example_slug>.py -v
+  ```
+
+- Refresh the upstream gallery snapshots before updating a test or
+  `status.json`:
+
+  ```bash
+  python misc/maplibre_examples/scrapping.py
+  ```
+
+- Recalculate the roadmap metrics so documentation reflects the latest
+  `status.json` values:
+
+  ```bash
+  python -c "import json; data = json.load(open('misc/maplibre_examples/status.json')); print(f'Total examples: {len(data)}');"
+  python -c "import json; data = json.load(open('misc/maplibre_examples/status.json')); implemented = sum(1 for v in data.values() if list(v.values())[0]['task_status']); print(f'Implemented: {implemented}'); print(f'Coverage: {implemented/len(data)*100:.1f}%')"
+  ```
+
+- See `misc/maplibre_examples/README.md` for the full roadmap, parity goals,
+  and additional helper commands that keep the gallery in sync.
 
 ## Usage
 

--- a/misc/maplibre_examples/README.md
+++ b/misc/maplibre_examples/README.md
@@ -139,6 +139,15 @@ This roadmap now reflects full parity with the 123 official MapLibre GL JS examp
 
 **Current Coverage:** 123/123 examples completed (100%). The remaining edge-case HTML samples—cooperative gestures, right-to-left scripts, mobile projections, and globe-specific styling—are reproduced entirely through generated HTML/JS with light-weight Python helpers where strictly necessary.
 
+#### Progress snapshot (regenerated 2025-09-22)
+
+| Metric | Value |
+| --- | --- |
+| Total examples tracked | 123 |
+| Examples downloaded | 123 |
+| Examples implemented | 123 |
+| Coverage percentage | 100% |
+
 ### Edge-case Validation
 
 - ✅ **Right-to-left script support** – Exercised via `Map.enable_rtl_text_plugin`, matching the `add-support-for-right-to-left-scripts` gallery example with automated pytest coverage.


### PR DESCRIPTION
## Summary
- split the CI workflow so the core suite, gallery suite, and any focused example tests run independently
- add a pull-request template that captures MapLibre example parity checks, status.json updates, and the regenerated progress snapshot
- expand the README contribution workflow and refresh the roadmap snapshot with the latest 123/123 coverage metrics

## Testing
- pytest -k "not test_examples"
- pytest tests/test_examples/ -v

------
https://chatgpt.com/codex/tasks/task_b_68d0dbf73cec832fa7e3c84ad1ace124