### PR TITLE
feat: Add BabylonLayer for 3D model integration

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -1,4 +1,5 @@
 from ._version import __version__
+from .babylon import BabylonLayer
 from .choropleth import Choropleth
 from .cluster import ClusteredGeoJson, MarkerCluster, cluster_features
 from .core import (GeoJson, GeoJsonPopup, GeoJsonTooltip, ImageOverlay,

--- a/maplibreum/babylon.py
+++ b/maplibreum/babylon.py
@@ -1,0 +1,132 @@
+"""Dedicated support for babylon.js custom layers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .layers import Layer
+
+
+class BabylonLayer(Layer):
+    """Represents a babylon.js custom layer for rendering 3D models."""
+
+    def __init__(
+        self,
+        id: str,
+        model_uri: str,
+        model_origin: List[float],
+        model_altitude: float = 0,
+        model_rotate: Optional[List[float]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize a BabylonLayer.
+
+        Parameters
+        ----------
+        id : str
+            The ID of the layer.
+        model_uri : str
+            The URI of the 3D model (e.g., in GLTF format).
+        model_origin : list of float
+            The [longitude, latitude] pair for the model's origin.
+        model_altitude : float, optional
+            The altitude of the model's origin in meters.
+        model_rotate : list of float, optional
+            The rotation of the model as ``[x, y, z]`` Euler angles.
+        """
+        super().__init__(id, "custom", **kwargs)
+        self.model_uri = model_uri
+        self.model_origin = model_origin
+        self.model_altitude = model_altitude
+        self.model_rotate = model_rotate or [0, 0, 0]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the layer definition as a plain dictionary."""
+        layer_dict = super().to_dict()
+        layer_dict["renderingMode"] = "3d"
+        return layer_dict
+
+    @property
+    def js_code(self) -> str:
+        """Generate the JavaScript code for the custom layer."""
+        return f"""
+const worldOrigin = [{self.model_origin[0]}, {self.model_origin[1]}];
+const worldAltitude = {self.model_altitude};
+const worldRotate = [{self.model_rotate[0]}, {self.model_rotate[1]}, {self.model_rotate[2]}];
+const worldOriginMercator = maplibregl.MercatorCoordinate.fromLngLat(
+    worldOrigin,
+    worldAltitude
+);
+const worldScale = worldOriginMercator.meterInMercatorCoordinateUnits();
+const worldMatrix = BABYLON.Matrix.Compose(
+    new BABYLON.Vector3(worldScale, worldScale, worldScale),
+    BABYLON.Quaternion.FromEulerAngles(
+        worldRotate[0],
+        worldRotate[1],
+        worldRotate[2]
+    ),
+    new BABYLON.Vector3(
+        worldOriginMercator.x,
+        worldOriginMercator.y,
+        worldOriginMercator.z
+    )
+);
+
+const customLayer = {{
+    id: '{self.id}',
+    type: 'custom',
+    renderingMode: '3d',
+    onAdd (map, gl) {{
+        this.engine = new BABYLON.Engine(
+            gl,
+            true,
+            {{
+                useHighPrecisionMatrix: true
+            }},
+            true
+        );
+        this.scene = new BABYLON.Scene(this.engine);
+        this.scene.autoClear = false;
+        this.scene.detachControl();
+
+        this.scene.beforeRender = () => {{
+            this.engine.wipeCaches(true);
+        }};
+        this.camera = new BABYLON.Camera(
+            'Camera',
+            new BABYLON.Vector3(0, 0, 0),
+            this.scene
+        );
+        const light = new BABYLON.HemisphericLight(
+            'light1',
+            new BABYLON.Vector3(0, 0, 100),
+            this.scene
+        );
+        light.intensity = 0.7;
+        new BABYLON.AxesViewer(this.scene, 10);
+        BABYLON.SceneLoader.LoadAssetContainerAsync(
+            '{self.model_uri}',
+            '',
+            this.scene
+        ).then((modelContainer) => {{
+            modelContainer.addAllToScene();
+            const rootMesh = modelContainer.createRootMesh();
+            const rootMesh2 = rootMesh.clone();
+            rootMesh2.position.x = 25;
+            rootMesh2.position.z = 25;
+        }});
+
+        this.map = map;
+    }},
+    render (gl, args) {{
+        const cameraMatrix = BABYLON.Matrix.FromArray(args.defaultProjectionData.mainMatrix);
+        const wvpMatrix = worldMatrix.multiply(cameraMatrix);
+        this.camera.freezeProjectionMatrix(wvpMatrix);
+        this.scene.render(false);
+        this.map.triggerRepaint();
+    }}
+}};
+map.on('style.load', () => {{
+    map.addLayer(customLayer);
+}});
+"""

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -11,6 +11,7 @@ from urllib.parse import quote
 from IPython.display import IFrame, display
 from jinja2 import Environment, FileSystemLoader
 
+from .babylon import BabylonLayer
 from .cluster import ClusteredGeoJson, MarkerCluster
 from .expressions import get as expr_get
 from .expressions import interpolate, var
@@ -470,8 +471,17 @@ class Map:
             self.add_source(source_name, source)
             layer_definition["source"] = source_name
 
-        layer_id = layer_definition.get("id", f"layer_{uuid.uuid4().hex}")
-        layer_definition["id"] = layer_id
+        if isinstance(layer_definition, BabylonLayer):
+            layer_id = layer_definition.id
+            self.add_external_script("https://unpkg.com/babylonjs@5.42.2/babylon.js")
+            self.add_external_script(
+                "https://unpkg.com/babylonjs-loaders@5.42.2/babylonjs.loaders.min.js"
+            )
+            self.add_on_load_js(layer_definition.js_code)
+            layer_definition = layer_definition.to_dict()
+        else:
+            layer_id = layer_definition.get("id", f"layer_{uuid.uuid4().hex}")
+            layer_definition["id"] = layer_id
 
         self.layers.append(
             {"id": layer_id, "definition": layer_definition, "before": before}

--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -31,8 +31,8 @@
       "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-with-babylonjs/",
       "source_status": true,
       "file_path": "misc/maplibre_examples/pages/add-a-3d-model-with-babylonjs.html",
-      "task_status": false,
-      "script": null
+      "task_status": true,
+      "script": "tests/test_examples/test_add_a_3d_model_with_babylonjs.py"
     }
   },
   "add-a-3d-model-with-shadow-using-threejs": {

--- a/tests/test_examples/test_add_a_3d_model_with_babylonjs.py
+++ b/tests/test_examples/test_add_a_3d_model_with_babylonjs.py
@@ -1,0 +1,32 @@
+"""Test for the add-a-3d-model-with-babylonjs MapLibre example."""
+import math
+
+from maplibreum import Map
+from maplibreum.babylon import BabylonLayer
+
+
+def test_add_a_3d_model_with_babylonjs():
+    """Validate that a custom babylon.js layer can be added."""
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[148.9819, -35.3981],
+        zoom=18,
+        pitch=60,
+        map_options={"canvasContextAttributes": {"antialias": True}},
+    )
+
+    layer = BabylonLayer(
+        id="3d-model",
+        model_uri="https://maplibre.org/maplibre-gl-js/docs/assets/34M_17/34M_17.gltf",
+        model_origin=[148.9819, -35.39847],
+        model_rotate=[math.pi / 2, 0, 0],
+    )
+
+    map_instance.add_layer(layer)
+
+    html = map_instance.render()
+    assert "babylon.js" in html
+    assert "babylonjs.loaders.min.js" in html
+    assert "new BABYLON.Engine" in html
+    assert "BABYLON.SceneLoader.LoadAssetContainerAsync" in html
+    assert "map.addLayer(customLayer);" in html


### PR DESCRIPTION
This commit introduces a new BabylonLayer class to simplify the process of adding 3D models to a map using babylon.js.

The new class abstracts away the JavaScript boilerplate for creating a custom layer, allowing users to add a 3D model with a few lines of Python code.

The Map.add_layer method has been updated to handle the new BabylonLayer, and a new test case has been added to cover the 'add-a-3d-model-with-babylonjs' example.