### PR TITLE
feat: Add three.js example for 3D model with shadows

### DIFF
--- a/maplibreum/__init__.py
+++ b/maplibreum/__init__.py
@@ -1,5 +1,6 @@
 from ._version import __version__
 from .babylon import BabylonLayer
+from .three import ThreeLayer
 from .choropleth import Choropleth
 from .cluster import ClusteredGeoJson, MarkerCluster, cluster_features
 from .core import (GeoJson, GeoJsonPopup, GeoJsonTooltip, ImageOverlay,

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -12,6 +12,7 @@ from IPython.display import IFrame, display
 from jinja2 import Environment, FileSystemLoader
 
 from .babylon import BabylonLayer
+from .three import ThreeLayer
 from .cluster import ClusteredGeoJson, MarkerCluster
 from .expressions import get as expr_get
 from .expressions import interpolate, var
@@ -476,6 +477,16 @@ class Map:
             self.add_external_script("https://unpkg.com/babylonjs@5.42.2/babylon.js")
             self.add_external_script(
                 "https://unpkg.com/babylonjs-loaders@5.42.2/babylonjs.loaders.min.js"
+            )
+            self.add_on_load_js(layer_definition.js_code)
+            layer_definition = layer_definition.to_dict()
+        elif isinstance(layer_definition, ThreeLayer):
+            layer_id = layer_definition.id
+            self.add_external_script(
+                "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.js"
+            )
+            self.add_external_script(
+                "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/js/loaders/GLTFLoader.js"
             )
             self.add_on_load_js(layer_definition.js_code)
             layer_definition = layer_definition.to_dict()

--- a/maplibreum/three.py
+++ b/maplibreum/three.py
@@ -1,0 +1,170 @@
+"""Dedicated support for three.js custom layers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .layers import Layer
+
+
+class ThreeLayer(Layer):
+    """Represents a three.js custom layer for rendering 3D models."""
+
+    def __init__(
+        self,
+        id: str,
+        model_uri: str,
+        model_origin: List[float],
+        model_altitude: float = 0,
+        model_rotate: Optional[List[float]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize a ThreeLayer.
+
+        Parameters
+        ----------
+        id : str
+            The ID of the layer.
+        model_uri : str
+            The URI of the 3D model (e.g., in GLTF format).
+        model_origin : list of float
+            The [longitude, latitude] pair for the model's origin.
+        model_altitude : float, optional
+            The altitude of the model's origin in meters.
+        model_rotate : list of float, optional
+            The rotation of the model as ``[x, y, z]`` Euler angles.
+        """
+        super().__init__(id, "custom", **kwargs)
+        self.model_uri = model_uri
+        self.model_origin = model_origin
+        self.model_altitude = model_altitude
+        self.model_rotate = model_rotate or [0, 0, 0]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the layer definition as a plain dictionary."""
+        layer_dict = super().to_dict()
+        layer_dict["renderingMode"] = "3d"
+        return layer_dict
+
+    @property
+    def js_code(self) -> str:
+        """Generate the JavaScript code for the custom layer."""
+        return f"""
+const modelOrigin = [{self.model_origin[0]}, {self.model_origin[1]}];
+const modelAltitude = {self.model_altitude};
+const modelRotate = [{self.model_rotate[0]}, {self.model_rotate[1]}, {self.model_rotate[2]}];
+
+const modelAsMercatorCoordinate = maplibregl.MercatorCoordinate.fromLngLat(
+    modelOrigin,
+    modelAltitude
+);
+
+const modelTransform = {{
+    translateX: modelAsMercatorCoordinate.x,
+    translateY: modelAsMercatorCoordinate.y,
+    translateZ: modelAsMercatorCoordinate.z,
+    rotateX: modelRotate[0],
+    rotateY: modelRotate[1],
+    rotateZ: modelRotate[2],
+    scale: modelAsMercatorCoordinate.meterInMercatorCoordinateUnits()
+}};
+
+const customLayer = {{
+    id: '{self.id}',
+    type: 'custom',
+    renderingMode: '3d',
+    onAdd: function (map, gl) {{
+        this.camera = new THREE.Camera();
+        this.scene = new THREE.Scene();
+
+        const directionalLight = new THREE.DirectionalLight(0xffffff, 1);
+        directionalLight.position.set(100, 100, 100);
+        directionalLight.castShadow = true;
+        this.scene.add(directionalLight);
+
+        directionalLight.shadow.camera.near = 0.1;
+        directionalLight.shadow.camera.far = 2000;
+        directionalLight.shadow.camera.left = -500;
+        directionalLight.shadow.camera.right = 500;
+        directionalLight.shadow.camera.top = 500;
+        directionalLight.shadow.camera.bottom = -500;
+
+        directionalLight.shadow.mapSize.width = 4096;
+        directionalLight.shadow.mapSize.height = 4096;
+
+        const groundGeometry = new THREE.PlaneGeometry(1000, 1000);
+        const groundMaterial = new THREE.ShadowMaterial({{ opacity: 0.5 }});
+        const ground = new THREE.Mesh(groundGeometry, groundMaterial);
+        ground.rotation.x = -Math.PI / 2;
+        ground.position.y = modelAsMercatorCoordinate.z;
+        ground.receiveShadow = true;
+        this.scene.add(ground);
+
+        const loader = new THREE.GLTFLoader();
+        loader.load(
+            '{self.model_uri}',
+            (gltf) => {{
+                gltf.scene.traverse(function (node) {{
+                    if (node.isMesh || node.isLight) {{
+                        node.castShadow = true;
+                        node.receiveShadow = true;
+                    }}
+                }});
+                this.scene.add(gltf.scene);
+            }}
+        );
+        this.map = map;
+
+        this.renderer = new THREE.WebGLRenderer({{
+            canvas: map.getCanvas(),
+            context: gl,
+            antialias: true
+        }});
+        this.renderer.shadowMap.enabled = true;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+        this.renderer.autoClear = false;
+    }},
+    render: function (gl, args) {{
+        const rotationX = new THREE.Matrix4().makeRotationAxis(
+            new THREE.Vector3(1, 0, 0),
+            modelTransform.rotateX
+        );
+        const rotationY = new THREE.Matrix4().makeRotationAxis(
+            new THREE.Vector3(0, 1, 0),
+            modelTransform.rotateY
+        );
+        const rotationZ = new THREE.Matrix4().makeRotationAxis(
+            new THREE.Vector3(0, 0, 1),
+            modelTransform.rotateZ
+        );
+
+        const m = new THREE.Matrix4().fromArray(args.defaultProjectionData.mainMatrix);
+        const l = new THREE.Matrix4()
+            .makeTranslation(
+                modelTransform.translateX,
+                modelTransform.translateY,
+                modelTransform.translateZ
+            )
+            .scale(
+                new THREE.Vector3(
+                    modelTransform.scale,
+                    -modelTransform.scale,
+                    modelTransform.scale
+                )
+            )
+            .multiply(rotationX)
+            .multiply(rotationY)
+            .multiply(rotationZ);
+
+        this.camera.projectionMatrix = m.multiply(l);
+        this.renderer.resetState();
+        this.renderer.render(this.scene, this.camera);
+        this.map.triggerRepaint();
+    }}
+}};
+
+map.on('style.load', () => {{
+    map.addLayer(customLayer);
+}});
+"""

--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -31,8 +31,8 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-with-shadow-using-threejs/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/add-a-3d-model-with-shadow-using-threejs.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_3d_model_with_shadow_using_threejs.py"
   },
   "add-a-canvas-source": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-canvas-source/",

--- a/tests/test_examples/test_add_a_3d_model_with_shadow_using_threejs.py
+++ b/tests/test_examples/test_add_a_3d_model_with_shadow_using_threejs.py
@@ -1,0 +1,33 @@
+import json
+from maplibreum import Map
+from maplibreum.three import ThreeLayer
+
+def test_add_a_3d_model_with_shadow_using_threejs():
+    model_origin = [148.9819, -35.39847]
+    model_altitude = 0
+    model_rotate = [1.5707963267948966, 0, 0]
+
+    map_obj = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[148.9819, -35.3981],
+        zoom=18,
+        pitch=60,
+        map_options={"canvasContextAttributes": {"antialias": True}},
+    )
+
+    three_layer = ThreeLayer(
+        id="3d-model",
+        model_uri="https://maplibre.org/maplibre-gl-js/docs/assets/34M_17/34M_17.gltf",
+        model_origin=model_origin,
+        model_altitude=model_altitude,
+        model_rotate=model_rotate,
+    )
+
+    map_obj.add_layer(three_layer)
+    html = map_obj.render()
+    assert "three.js" in html
+    assert "GLTFLoader.js" in html
+    assert '"renderingMode": "3d"' in html
+    assert "directionalLight.castShadow = true;" in html
+    assert "renderer.shadowMap.enabled = true;" in html
+    assert "ground.receiveShadow = true;" in html


### PR DESCRIPTION
This commit implements the `add-a-3d-model-with-shadow-using-threejs` example from the official MapLibre GL JS documentation.

A new `ThreeLayer` class has been added to `maplibreum/three.py` to provide a high-level abstraction for creating `three.js` custom layers. This class is modeled after the existing `BabylonLayer` and handles the generation of the necessary JavaScript code for rendering.

The `maplibreum/core.py` file has been updated to automatically load the required `three.js` and `GLTFLoader` scripts when a `ThreeLayer` is added to the map.

A new test file, `tests/test_examples/test_add_a_3d_model_with_shadow_using_threejs.py`, has been created to validate the implementation.

The `misc/maplibre_examples/status.json` file has been updated to reflect the completion of this example.