### PR TITLE
Add parity tests for MapLibre animation and camera examples

### DIFF
--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -236,43 +236,43 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-marker/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/animate-a-marker.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_animate_a_marker.py"
     },
     "animate-a-point": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/animate-a-point.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_animate_a_point.py"
     },
     "animate-a-point-along-a-route": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point-along-a-route/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/animate-a-point-along-a-route.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_animate_a_point_along_a_route.py"
     },
     "animate-a-series-of-images": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-series-of-images/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/animate-a-series-of-images.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_animate_a_series_of_images.py"
     },
     "animate-map-camera-around-a-point": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-map-camera-around-a-point/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/animate-map-camera-around-a-point.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_animate_map_camera_around_a_point.py"
     },
     "animate-symbol-to-follow-the-mouse": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-symbol-to-follow-the-mouse/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/animate-symbol-to-follow-the-mouse.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_animate_symbol_to_follow_the_mouse.py"
     },
     "attach-a-popup-to-a-marker-instance": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/attach-a-popup-to-a-marker-instance/",
@@ -285,8 +285,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/center-the-map-on-a-clicked-symbol/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/center-the-map-on-a-clicked-symbol.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_center_the_map_on_a_clicked_symbol.py"
     },
     "change-a-layers-color-with-buttons": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-a-layers-color-with-buttons/",
@@ -404,8 +404,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/customize-camera-animations/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/customize-camera-animations.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_customize_camera_animations.py"
     },
     "disable-map-rotation": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/disable-map-rotation/",
@@ -607,22 +607,22 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fit-to-the-bounds-of-a-linestring/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/fit-to-the-bounds-of-a-linestring.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_fit_to_the_bounds_of_a_linestring.py"
     },
     "fly-to-a-location": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fly-to-a-location/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/fly-to-a-location.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_fly_to_a_location.py"
     },
     "fly-to-a-location-based-on-scroll-position": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fly-to-a-location-based-on-scroll-position/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/fly-to-a-location-based-on-scroll-position.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_fly_to_a_location_based_on_scroll_position.py"
     },
     "generate-and-add-a-missing-icon-to-the-map": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/generate-and-add-a-missing-icon-to-the-map/",
@@ -663,8 +663,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/jump-to-a-series-of-locations/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/jump-to-a-series-of-locations.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_jump_to_a_series_of_locations.py"
     },
     "level-of-detail-control": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/level-of-detail-control/",
@@ -698,8 +698,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/offset-the-vanishing-point-using-padding/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/offset-the-vanishing-point-using-padding.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_offset_the_vanishing_point_using_padding.py"
     },
     "pmtiles-source-and-protocol": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/pmtiles-source-and-protocol/",
@@ -754,8 +754,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/slowly-fly-to-a-location/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/slowly-fly-to-a-location.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_slowly_fly_to_a_location.py"
     },
     "style-lines-with-a-data-driven-property": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/style-lines-with-a-data-driven-property/",

--- a/tests/test_examples/test_animate_a_marker.py
+++ b/tests/test_examples/test_animate_a_marker.py
@@ -1,0 +1,42 @@
+"""Parity test for the animate-a-marker MapLibre example."""
+
+from maplibreum.core import Map
+from maplibreum.animation import AnimationLoop
+
+
+def test_animate_a_marker():
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[0, 0],
+        zoom=2,
+    )
+
+    marker_loop = AnimationLoop(
+        name="animateMarker",
+        auto_schedule=False,
+        start_immediately=False,
+        setup=[
+            "const marker = new maplibregl.Marker();",
+            "const radius = 20;",
+            "requestAnimationFrame(animateMarker);",
+        ],
+        body=[
+            "marker.setLngLat([",
+            "    Math.cos(timestamp / 1000) * radius,",
+            "    Math.sin(timestamp / 1000) * radius",
+            "]);",
+            "marker.addTo(map);",
+            "requestAnimationFrame(animateMarker);",
+        ],
+    )
+
+    m.add_animation(marker_loop)
+
+    html = m.render()
+
+    assert '"style": "https://demotiles.maplibre.org/style.json"' in html
+    assert '"center": [0, 0]' in html
+    assert '"zoom": 2' in html
+    assert "new maplibregl.Marker()" in html
+    assert "Math.cos(timestamp / 1000) * radius" in html
+    assert "requestAnimationFrame(animateMarker);" in html

--- a/tests/test_examples/test_animate_a_point.py
+++ b/tests/test_examples/test_animate_a_point.py
@@ -1,0 +1,64 @@
+"""Parity test for the animate-a-point MapLibre example."""
+
+from maplibreum.core import Map
+from maplibreum import layers
+from maplibreum.animation import AnimationLoop
+
+
+def test_animate_a_point():
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[0, 0],
+        zoom=2,
+    )
+
+    m.add_source(
+        "point",
+        {
+            "type": "geojson",
+            "data": {
+                "type": "Point",
+                "coordinates": [20, 0],
+            },
+        },
+    )
+
+    m.add_layer(
+        layers.CircleLayer(
+            id="point",
+            source="point",
+            paint={"circle-radius": 10, "circle-color": "#007cbf"},
+        ).to_dict()
+    )
+
+    point_loop = AnimationLoop(
+        name="animateMarker",
+        auto_schedule=False,
+        start_immediately=False,
+        setup=[
+            "const radius = 20;",
+            "function pointOnCircle(angle) {",
+            "    return {",
+            "        'type': 'Point',",
+            "        'coordinates': [Math.cos(angle) * radius, Math.sin(angle) * radius]",
+            "    };",
+            "}",
+            "animateMarker(0);",
+        ],
+        body=[
+            "map.getSource('point').setData(pointOnCircle(timestamp / 1000));",
+            "requestAnimationFrame(animateMarker);",
+        ],
+    )
+
+    m.add_animation(point_loop)
+
+    html = m.render()
+
+    assert '"style": "https://demotiles.maplibre.org/style.json"' in html
+    assert '"center": [0, 0]' in html
+    assert '"zoom": 2' in html
+    assert 'map.addSource("point"' in html
+    assert 'map.addLayer({"id": "point"' in html
+    assert "function pointOnCircle" in html
+    assert "map.getSource('point').setData(pointOnCircle" in html

--- a/tests/test_examples/test_animate_a_point_along_a_route.py
+++ b/tests/test_examples/test_animate_a_point_along_a_route.py
@@ -1,0 +1,181 @@
+"""Parity test for the animate-a-point-along-a-route MapLibre example."""
+
+import json
+
+from maplibreum.core import Map
+from maplibreum import layers
+from maplibreum.animation import AnimationLoop
+
+
+def test_animate_a_point_along_a_route():
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-96, 37.8],
+        zoom=3,
+    )
+
+    m.custom_css = """
+    .maplibreum-animate-route-overlay {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        z-index: 1;
+    }
+
+    .maplibreum-animate-route-overlay button {
+        font: 600 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+        background-color: #3386c0;
+        color: #fff;
+        display: inline-block;
+        margin: 0;
+        padding: 10px 20px;
+        border: none;
+        cursor: pointer;
+        border-radius: 3px;
+    }
+
+    .maplibreum-animate-route-overlay button:hover {
+        background-color: #4ea0da;
+    }
+    """.strip()
+
+    m.add_external_script(
+        "https://www.unpkg.com/turf@2.0.0/turf.min.js",
+        attributes={"charset": "utf-8"},
+    )
+
+    route_data = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[-122.414, 37.776], [-77.032, 38.913]],
+                },
+            }
+        ],
+    }
+
+    point_data = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "Point", "coordinates": [-122.414, 37.776]},
+            }
+        ],
+    }
+
+    m.add_source("route", {"type": "geojson", "data": route_data})
+    m.add_source("point", {"type": "geojson", "data": point_data})
+
+    m.add_layer(
+        layers.LineLayer(
+            id="route",
+            source="route",
+            paint={"line-width": 2, "line-color": "#007cbf"},
+        ).to_dict()
+    )
+
+    m.add_layer(
+        layers.SymbolLayer(
+            id="point",
+            source="point",
+            layout={
+                "icon-image": "airport",
+                "icon-rotate": ["get", "bearing"],
+                "icon-rotation-alignment": "map",
+                "icon-overlap": "always",
+                "icon-ignore-placement": True,
+            },
+        ).to_dict()
+    )
+
+    m.add_on_load_js(
+        "\n".join(
+            [
+                "const overlay = document.createElement('div');",
+                "overlay.className = 'maplibreum-animate-route-overlay';",
+                "const button = document.createElement('button');",
+                "button.id = 'replay';",
+                "button.textContent = 'Replay';",
+                "overlay.appendChild(button);",
+                "map.getContainer().appendChild(overlay);",
+            ]
+        )
+    )
+
+    route_js = json.dumps(route_data)
+    point_js = json.dumps(point_data)
+
+    loop_setup = [
+        f"const route = {route_js};",
+        f"const point = {point_js};",
+        "const steps = 500;",
+        "const lineDistance = turf.lineDistance(route.features[0], 'kilometers');",
+        "const arc = [];",
+        "for (let i = 0; i < lineDistance; i += lineDistance / steps) {",
+        "    const segment = turf.along(route.features[0], i, 'kilometers');",
+        "    arc.push(segment.geometry.coordinates);",
+        "}",
+        "route.features[0].geometry.coordinates = arc;",
+        "map.getSource('route').setData(route);",
+        "map.getSource('point').setData(point);",
+        "const replayButton = document.getElementById('replay');",
+        "if (replayButton) {",
+        "    replayButton.addEventListener('click', () => {",
+        "        point.features[0].geometry.coordinates = route.features[0].geometry.coordinates[0];",
+        "        map.getSource('point').setData(point);",
+        "        counter = 0;",
+        "        animate(0);",
+        "    });",
+        "}",
+        "animate(0);",
+    ]
+
+    loop_body = [
+        "point.features[0].geometry.coordinates =",
+        "    route.features[0].geometry.coordinates[counter];",
+        "point.features[0].properties.bearing = turf.bearing(",
+        "    turf.point(",
+        "        route.features[0].geometry.coordinates[",
+        "            counter >= steps ? counter - 1 : counter",
+        "        ]",
+        "    ),",
+        "    turf.point(",
+        "        route.features[0].geometry.coordinates[",
+        "            counter >= steps ? counter : counter + 1",
+        "        ]",
+        "    )",
+        ");",
+        "map.getSource('point').setData(point);",
+        "if (counter < steps) {",
+        "    requestAnimationFrame(animate);",
+        "}",
+        "counter = counter + 1;",
+    ]
+
+    m.add_animation(
+        AnimationLoop(
+            name="animate",
+            variables={"counter": "0"},
+            auto_schedule=False,
+            start_immediately=False,
+            setup=loop_setup,
+            body=loop_body,
+        )
+    )
+
+    html = m.render()
+
+    assert '"style": "https://tiles.openfreemap.org/styles/bright"' in html
+    assert '"center": [-96, 37.8]' in html
+    assert '"zoom": 3' in html
+    assert 'map.addSource("route"' in html
+    assert 'map.addSource("point"' in html
+    assert "turf.lineDistance" in html
+    assert "turf.along" in html
+    assert "requestAnimationFrame(animate);" in html
+    assert "document.getElementById('replay')" in html

--- a/tests/test_examples/test_animate_a_series_of_images.py
+++ b/tests/test_examples/test_animate_a_series_of_images.py
@@ -1,0 +1,62 @@
+"""Parity test for the animate-a-series-of-images MapLibre example."""
+
+from maplibreum.core import Map
+from maplibreum import layers
+
+
+def test_animate_a_series_of_images():
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-75.789, 41.874],
+        zoom=5,
+        map_options={"minZoom": 4, "maxZoom": 5.99},
+    )
+
+    m.add_source(
+        "radar",
+        {
+            "type": "image",
+            "url": "https://maplibre.org/maplibre-gl-js/docs/assets/radar0.gif",
+            "coordinates": [
+                [-80.425, 46.437],
+                [-71.516, 46.437],
+                [-71.516, 37.936],
+                [-80.425, 37.936],
+            ],
+        },
+    )
+
+    m.add_layer(
+        layers.RasterLayer(
+            id="radar-layer",
+            source="radar",
+            paint={"raster-fade-duration": 0},
+        ).to_dict()
+    )
+
+    animation_script = "\n".join(
+        [
+            "const frameCount = 5;",
+            "let currentImage = 0;",
+            "function getPath() {",
+            "    return `https://maplibre.org/maplibre-gl-js/docs/assets/radar${currentImage}.gif`;",
+            "}",
+            "setInterval(() => {",
+            "    currentImage = (currentImage + 1) % frameCount;",
+            "    map.getSource('radar').updateImage({url: getPath()});",
+            "}, 200);",
+        ]
+    )
+
+    m.add_animation(animation_script)
+
+    html = m.render()
+
+    assert '"style": "https://demotiles.maplibre.org/style.json"' in html
+    assert '"center": [-75.789, 41.874]' in html
+    assert '"zoom": 5' in html
+    assert '"minZoom": 4' in html
+    assert '"maxZoom": 5.99' in html
+    assert 'map.addSource("radar"' in html
+    assert "map.getSource('radar').updateImage({url: getPath()});" in html
+    assert "setInterval(() => {" in html

--- a/tests/test_examples/test_animate_map_camera_around_a_point.py
+++ b/tests/test_examples/test_animate_map_camera_around_a_point.py
@@ -1,0 +1,42 @@
+"""Parity test for the animate-map-camera-around-a-point example."""
+
+from maplibreum.core import Map
+from maplibreum.animation import AnimationLoop
+
+
+def test_animate_map_camera_around_a_point():
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/liberty",
+        center=[-87.62712, 41.89033],
+        zoom=15.5,
+        pitch=45,
+    )
+
+    m.add_on_load_js(
+        "\n".join(
+            [
+                "const layers = map.getStyle().layers;",
+                "for (let i = 0; i < layers.length; i++) {",
+                "    if (layers[i].type === 'symbol' && layers[i].layout && layers[i].layout['text-field']) {",
+                "        map.removeLayer(layers[i].id);",
+                "    }",
+                "}",
+            ]
+        )
+    )
+
+    m.add_animation(
+        AnimationLoop(
+            name="rotateCamera",
+            body="map.rotateTo((timestamp / 100) % 360, {duration: 0});",
+        )
+    )
+
+    html = m.render()
+
+    assert '"style": "https://tiles.openfreemap.org/styles/liberty"' in html
+    assert '"center": [-87.62712, 41.89033]' in html
+    assert '"zoom": 15.5' in html
+    assert '"pitch": 45' in html
+    assert "map.rotateTo((timestamp / 100) % 360, {duration: 0});" in html
+    assert "map.removeLayer(layers[i].id);" in html

--- a/tests/test_examples/test_animate_symbol_to_follow_the_mouse.py
+++ b/tests/test_examples/test_animate_symbol_to_follow_the_mouse.py
@@ -1,0 +1,56 @@
+"""Parity test for the animate-symbol-to-follow-the-mouse example."""
+
+from maplibreum.core import Map
+from maplibreum import layers
+
+
+def test_animate_symbol_to_follow_the_mouse():
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[0, 0],
+        zoom=2,
+        map_options={"projection": {"type": "globe"}},
+    )
+
+    m.add_control("globe")
+
+    m.add_source(
+        "point",
+        {
+            "type": "geojson",
+            "data": {"type": "Point", "coordinates": [0, 0]},
+        },
+    )
+
+    m.add_layer(
+        layers.CircleLayer(
+            id="point",
+            source="point",
+            paint={"circle-radius": 10, "circle-color": "#007cbf"},
+        ).to_dict()
+    )
+
+    m.add_event_listener(
+        "mousemove",
+        js="\n".join(
+            [
+                "const lngLat = event.lngLat.wrap();",
+                "const pointSource = map.getSource('point');",
+                "if (pointSource && lngLat.lng && lngLat.lat) {",
+                "    pointSource.setData({",
+                "        'type': 'Point',",
+                "        'coordinates': [lngLat.lng, lngLat.lat]",
+                "    });",
+                "}",
+            ]
+        ),
+    )
+
+    html = m.render()
+
+    assert '"projection": {"type": "globe"}' in html
+    assert '"center": [0, 0]' in html
+    assert '"zoom": 2' in html
+    assert 'map.addSource("point"' in html
+    assert "map.getSource('point')" in html
+    assert "event.lngLat.wrap" in html

--- a/tests/test_examples/test_center_the_map_on_a_clicked_symbol.py
+++ b/tests/test_examples/test_center_the_map_on_a_clicked_symbol.py
@@ -1,0 +1,95 @@
+"""Parity test for the center-the-map-on-a-clicked-symbol example."""
+
+from maplibreum.core import Map
+from maplibreum import layers
+
+
+def test_center_the_map_on_a_clicked_symbol():
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-90.96, -0.47],
+        zoom=7.5,
+    )
+
+    m.add_image(
+        "custom-marker",
+        url="https://maplibre.org/maplibre-gl-js/docs/assets/custom_marker.png",
+    )
+
+    m.add_source(
+        "points",
+        {
+            "type": "geojson",
+            "data": {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {},
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": [-91.395263671875, -0.9145729757782163],
+                        },
+                    },
+                    {
+                        "type": "Feature",
+                        "properties": {},
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": [-90.32958984375, -0.6344474832838974],
+                        },
+                    },
+                    {
+                        "type": "Feature",
+                        "properties": {},
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": [-91.34033203125, 0.01647949196029245],
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+    m.add_layer(
+        layers.SymbolLayer(
+            id="symbols",
+            source="points",
+            layout={"icon-image": "custom-marker"},
+        ).to_dict()
+    )
+
+    m.add_event_listener(
+        "click",
+        layer_id="symbols",
+        js="\n".join(
+            [
+                "map.flyTo({",
+                "    center: event.features[0].geometry.coordinates",
+                "});",
+            ]
+        ),
+    )
+
+    m.add_event_listener(
+        "mouseenter",
+        layer_id="symbols",
+        js="map.getCanvas().style.cursor = 'pointer';",
+    )
+
+    m.add_event_listener(
+        "mouseleave",
+        layer_id="symbols",
+        js="map.getCanvas().style.cursor = '';",
+    )
+
+    html = m.render()
+
+    assert '"style": "https://demotiles.maplibre.org/style.json"' in html
+    assert '"center": [-90.96, -0.47]' in html
+    assert '"zoom": 7.5' in html
+    assert "custom_marker.png" in html
+    assert 'map.addSource("points"' in html
+    assert "map.flyTo({" in html
+    assert "map.getCanvas().style.cursor = 'pointer';" in html

--- a/tests/test_examples/test_customize_camera_animations.py
+++ b/tests/test_examples/test_customize_camera_animations.py
@@ -1,0 +1,221 @@
+"""Parity test for the customize-camera-animations MapLibre example."""
+
+from maplibreum.core import Map
+from maplibreum import layers
+
+
+def test_customize_camera_animations():
+    overlay_css = """
+    .map-overlay {
+        font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+        position: absolute;
+        width: 200px;
+        top: 0;
+        left: 0;
+        padding: 10px;
+    }
+
+    .map-overlay .map-overlay-inner {
+        background-color: #fff;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+        border-radius: 3px;
+        padding: 10px;
+        margin-bottom: 10px;
+    }
+
+    .map-overlay-inner fieldset {
+        border: none;
+        padding: 0;
+        margin: 0 0 10px;
+    }
+
+    .map-overlay-inner fieldset:last-child {
+        margin: 0;
+    }
+
+    .map-overlay-inner select {
+        width: 100%;
+    }
+
+    .map-overlay-inner button {
+        background-color: cornflowerblue;
+        color: white;
+        border-radius: 5px;
+        display: inline-block;
+        height: 20px;
+        border: none;
+        cursor: pointer;
+    }
+
+    .map-overlay-inner button:hover {
+        background-color: blue;
+        box-shadow: inset 0 0 0 3px rgba(0, 0, 0, 0.1);
+        transition: background-color 500ms linear;
+    }
+
+    .offset > label,
+    .offset > input {
+        display: inline;
+    }
+
+    #animateLabel {
+        display: inline-block;
+        min-width: 20px;
+    }
+    """.strip()
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-95, 40],
+        zoom=3,
+        custom_css=overlay_css,
+    )
+
+    m.add_source(
+        "center",
+        {
+            "type": "geojson",
+            "data": {"type": "Point", "coordinates": [-94, 40]},
+        },
+    )
+
+    m.add_layer(
+        layers.SymbolLayer(
+            id="center",
+            source="center",
+            layout={
+                "text-field": "Center: [-94, 40]",
+                "text-font": ["Noto Sans Regular"],
+                "text-offset": [0, 0.6],
+                "text-anchor": "top",
+            },
+        ).to_dict()
+    )
+
+    m.add_layer(
+        layers.CircleLayer(
+            id="center-circle",
+            source="center",
+            paint={"circle-radius": 6, "circle-color": "#007cbf"},
+        ).to_dict()
+    )
+
+    overlay_js = "\n".join(
+        [
+            "const overlay = document.createElement('div');",
+            "overlay.className = 'map-overlay top';",
+            "overlay.innerHTML = `",
+            "    <div class=\"map-overlay-inner\">",
+            "        <fieldset>",
+            "            <label for=\"easing\">Select easing function</label>",
+            "            <select id=\"easing\" name=\"easing\">",
+            "                <option value=\"easeInCubic\">Ease In Cubic</option>",
+            "                <option value=\"easeOutQuint\">Ease Out Quint</option>",
+            "                <option value=\"easeInOutCirc\">Ease In/Out Circ</option>",
+            "                <option value=\"easeOutBounce\">Ease Out Bounce</option>",
+            "            </select>",
+            "        </fieldset>",
+            "        <fieldset>",
+            "            <label for=\"duration\">Set animation duration</label>",
+            "            <p id=\"durationValue\"></p>",
+            "            <input type=\"range\" id=\"duration\" name=\"duration\" min=\"0\" max=\"10000\" step=\"500\" value=\"1000\" />",
+            "        </fieldset>",
+            "        <fieldset>",
+            "            <label>Animate camera motion</label>",
+            "            <label for=\"animate\" id=\"animateLabel\">Yes</label>",
+            "            <input type=\"checkbox\" id=\"animate\" name=\"animate\" checked />",
+            "        </fieldset>",
+            "        <fieldset class=\"offset\">",
+            "            <label for=\"offset-x\">Offset-X</label>",
+            "            <input type=\"number\" id=\"offset-x\" name=\"offset-x\" min=\"-200\" max=\"200\" step=\"50\" value=\"0\" />",
+            "        </fieldset>",
+            "        <fieldset class=\"offset\">",
+            "            <label for=\"offset-y\">Offset-Y</label>",
+            "            <input type=\"number\" id=\"offset-y\" name=\"offset-y\" min=\"-200\" max=\"200\" step=\"50\" value=\"0\" />",
+            "            <p>Offsets can be negative</p>",
+            "        </fieldset>",
+            "        <button type=\"button\" id=\"animateButton\" name=\"test-animation\">Test Animation</button>",
+            "    </div>",
+            "`;",
+            "document.body.appendChild(overlay);",
+            "const easingFunctions = {",
+            "    easeInCubic(t) {",
+            "        return t * t * t;",
+            "    },",
+            "    easeOutQuint(t) {",
+            "        return 1 - Math.pow(1 - t, 5);",
+            "    },",
+            "    easeInOutCirc(t) {",
+            "        return t < 0.5 ?",
+            "            (1 - Math.sqrt(1 - Math.pow(2 * t, 2))) / 2 :",
+            "            (Math.sqrt(1 - Math.pow(-2 * t + 2, 2)) + 1) / 2;",
+            "    },",
+            "    easeOutBounce(t) {",
+            "        const n1 = 7.5625;",
+            "        const d1 = 2.75;",
+            "        if (t < 1 / d1) {",
+            "            return n1 * t * t;",
+            "        } else if (t < 2 / d1) {",
+            "            return n1 * (t -= 1.5 / d1) * t + 0.75;",
+            "        } else if (t < 2.5 / d1) {",
+            "            return n1 * (t -= 2.25 / d1) * t + 0.9375;",
+            "        }",
+            "        return n1 * (t -= 2.625 / d1) * t + 0.984375;",
+            "    }",
+            "};",
+            "const durationValueSpan = document.getElementById('durationValue');",
+            "const durationInput = document.getElementById('duration');",
+            "durationValueSpan.innerHTML = `${durationInput.value / 1000} seconds`;",
+            "durationInput.addEventListener('change', (e) => {",
+            "    durationValueSpan.innerHTML = `${e.target.value / 1000} seconds`;",
+            "});",
+            "const animateLabel = document.getElementById('animateLabel');",
+            "const animateValue = document.getElementById('animate');",
+            "animateValue.addEventListener('change', (e) => {",
+            "    animateLabel.innerHTML = e.target.checked ? 'Yes' : 'No';",
+            "});",
+            "const animateButton = document.getElementById('animateButton');",
+            "animateButton.addEventListener('click', () => {",
+            "    const easingInput = document.getElementById('easing');",
+            "    const easingFn = easingFunctions[easingInput.options[easingInput.selectedIndex].value];",
+            "    const duration = parseInt(durationInput.value, 10);",
+            "    const animate = animateValue.checked;",
+            "    const offsetX = parseInt(document.getElementById('offset-x').value, 10);",
+            "    const offsetY = parseInt(document.getElementById('offset-y').value, 10);",
+            "    const animationOptions = {",
+            "        duration,",
+            "        easing: easingFn,",
+            "        offset: [offsetX, offsetY],",
+            "        animate,",
+            "        essential: true",
+            "    };",
+            "    const center = [",
+            "        -95 + (Math.random() - 0.5) * 20,",
+            "        40 + (Math.random() - 0.5) * 20",
+            "    ];",
+            "    animationOptions.center = center;",
+            "    map.flyTo(animationOptions);",
+            "    map.getSource('center').setData({",
+            "        'type': 'Point',",
+            "        'coordinates': center",
+            "    });",
+            "    map.setLayoutProperty(",
+            "        'center',",
+            "        'text-field',",
+            "        `Center: [${center[0].toFixed(1)}, ${center[1].toFixed(1)}]`",
+            "    );",
+            "});",
+        ]
+    )
+
+    m.add_on_load_js(overlay_js)
+
+    html = m.render()
+
+    assert '"style": "https://demotiles.maplibre.org/style.json"' in html
+    assert '"center": [-95, 40]' in html
+    assert '"zoom": 3' in html
+    assert 'map.addSource("center"' in html
+    assert "map.flyTo(animationOptions);" in html
+    assert "animationOptions.center = center" in html
+    assert "map.setLayoutProperty(\n        'center'" in html

--- a/tests/test_examples/test_fit_to_the_bounds_of_a_linestring.py
+++ b/tests/test_examples/test_fit_to_the_bounds_of_a_linestring.py
@@ -1,0 +1,110 @@
+"""Parity test for the fit-to-the-bounds-of-a-linestring example."""
+
+import json
+
+from maplibreum.core import Map
+from maplibreum import layers
+
+
+def test_fit_to_the_bounds_of_a_linestring():
+    button_css = """
+    .maplibreum-zoomto {
+        font: bold 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+        background-color: #3386c0;
+        color: #fff;
+        position: absolute;
+        top: 20px;
+        left: 50%;
+        z-index: 1;
+        border: none;
+        width: 200px;
+        margin-left: -100px;
+        display: block;
+        cursor: pointer;
+        padding: 10px 20px;
+        border-radius: 3px;
+    }
+
+    .maplibreum-zoomto:hover {
+        background-color: #4ea0da;
+    }
+    """.strip()
+
+    line_coordinates = [
+        [-77.0366048812866, 38.89873175227713],
+        [-77.03364372253417, 38.89876515143842],
+        [-77.03364372253417, 38.89549195896866],
+        [-77.02982425689697, 38.89549195896866],
+        [-77.02400922775269, 38.89387200688839],
+        [-77.01519012451172, 38.891416957534204],
+        [-77.01521158218382, 38.892068305429156],
+        [-77.00813055038452, 38.892051604275686],
+        [-77.00832366943358, 38.89143365883688],
+        [-77.00818419456482, 38.89082405874451],
+        [-77.00815200805664, 38.88989712255097],
+    ]
+
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-77.0214, 38.897],
+        zoom=12,
+        custom_css=button_css,
+    )
+
+    m.add_source(
+        "LineString",
+        {
+            "type": "geojson",
+            "data": {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": line_coordinates,
+                        },
+                    }
+                ],
+            },
+        },
+    )
+
+    m.add_layer(
+        layers.LineLayer(
+            id="LineString",
+            source="LineString",
+            layout={"line-join": "round", "line-cap": "round"},
+            paint={"line-color": "#BF93E4", "line-width": 5},
+        ).to_dict()
+    )
+
+    coords_js = json.dumps(line_coordinates)
+
+    m.add_on_load_js(
+        "\n".join(
+            [
+                "const zoomButton = document.createElement('button');",
+                "zoomButton.id = 'zoomto';",
+                "zoomButton.className = 'maplibreum-zoomto';",
+                "zoomButton.textContent = 'Zoom to bounds';",
+                "document.body.appendChild(zoomButton);",
+                f"const lineCoordinates = {coords_js};",
+                "zoomButton.addEventListener('click', () => {",
+                "    const bounds = lineCoordinates.reduce((acc, coord) => {",
+                "        return acc.extend(coord);",
+                "    }, new maplibregl.LngLatBounds(lineCoordinates[0], lineCoordinates[0]));",
+                "    map.fitBounds(bounds, { padding: 20 });",
+                "});",
+            ]
+        )
+    )
+
+    html = m.render()
+
+    assert '"style": "https://tiles.openfreemap.org/styles/bright"' in html
+    assert '"center": [-77.0214, 38.897]' in html
+    assert '"zoom": 12' in html
+    assert 'map.addSource("LineString"' in html
+    assert "map.fitBounds(bounds, { padding: 20 });" in html
+    assert "maplibregl.LngLatBounds" in html

--- a/tests/test_examples/test_fly_to_a_location.py
+++ b/tests/test_examples/test_fly_to_a_location.py
@@ -1,0 +1,61 @@
+"""Parity test for the fly-to-a-location MapLibre example."""
+
+from maplibreum.core import Map
+
+
+def test_fly_to_a_location():
+    button_css = """
+    .maplibreum-fly-button {
+        display: block;
+        position: absolute;
+        top: 20px;
+        left: 50%;
+        transform: translate(-50%);
+        width: 50%;
+        height: 40px;
+        padding: 10px;
+        border: none;
+        border-radius: 3px;
+        font-size: 12px;
+        text-align: center;
+        color: #fff;
+        background: #ee8a65;
+        cursor: pointer;
+    }
+    """.strip()
+
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-74.5, 40],
+        zoom=9,
+        custom_css=button_css,
+    )
+
+    m.add_on_load_js(
+        "\n".join(
+            [
+                "const flyButton = document.createElement('button');",
+                "flyButton.id = 'fly';",
+                "flyButton.className = 'maplibreum-fly-button';",
+                "flyButton.textContent = 'Fly';",
+                "document.body.appendChild(flyButton);",
+                "flyButton.addEventListener('click', () => {",
+                "    map.flyTo({",
+                "        center: [",
+                "            -74.5 + (Math.random() - 0.5) * 10,",
+                "            40 + (Math.random() - 0.5) * 10",
+                "        ],",
+                "        essential: true",
+                "    });",
+                "});",
+            ]
+        )
+    )
+
+    html = m.render()
+
+    assert '"style": "https://tiles.openfreemap.org/styles/bright"' in html
+    assert '"center": [-74.5, 40]' in html
+    assert '"zoom": 9' in html
+    assert "map.flyTo({" in html
+    assert "essential: true" in html

--- a/tests/test_examples/test_fly_to_a_location_based_on_scroll_position.py
+++ b/tests/test_examples/test_fly_to_a_location_based_on_scroll_position.py
@@ -1,0 +1,131 @@
+"""Parity test for the fly-to-a-location-based-on-scroll-position example."""
+
+from maplibreum.core import Map
+
+
+def test_fly_to_a_location_based_on_scroll_position():
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-0.15591514, 51.51830379],
+        zoom=15.5,
+        bearing=27,
+        pitch=45,
+    )
+
+    m.custom_css = "\n".join(
+        [
+            f"#{m.map_id} {{ position: fixed; width: 50%; }}",
+            ".maplibreum-story {",
+            "    width: 50%;",
+            "    margin-left: 50%;",
+            "    font-family: sans-serif;",
+            "    overflow-y: scroll;",
+            "    background-color: #fafafa;",
+            "}",
+            ".maplibreum-story section {",
+            "    padding: 25px 50px;",
+            "    line-height: 25px;",
+            "    border-bottom: 1px solid #ddd;",
+            "    opacity: 0.25;",
+            "    font-size: 13px;",
+            "}",
+            ".maplibreum-story section.active { opacity: 1; }",
+            ".maplibreum-story section:last-child { border-bottom: none; margin-bottom: 200px; }",
+        ]
+    )
+
+    story_html = """
+    <section id="baker" class="active">
+        <h3>221b Baker St.</h3>
+        <p>November 1895. London is shrouded in fog and Sherlock Holmes and Watson await a new case.</p>
+    </section>
+    <section id="aldgate">
+        <h3>Aldgate Station</h3>
+        <p>Arthur Cadogan West is found dead on the tracks at Aldgate Station with submarine plans missing.</p>
+    </section>
+    <section id="london-bridge">
+        <h3>London Bridge</h3>
+        <p>Holmes dispatches a telegram to Mycroft at London Bridge to gather intelligence on foreign spies.</p>
+    </section>
+    <section id="woolwich">
+        <h3>Woolwich Arsenal</h3>
+        <p>Investigations reveal West lacked the keys required to steal the plans, raising new suspicions.</p>
+    </section>
+    <section id="gloucester">
+        <h3>Gloucester Road</h3>
+        <p>Holmes inspects Caulfield Gardens, noting trains pause beneath the suspect's apartment windows.</p>
+    </section>
+    <section id="caulfield-gardens">
+        <h3>13 Caulfield Gardens</h3>
+        <p>Evidence suggests the murderer loaded West onto a train at Caulfield Gardens before the fatal fall.</p>
+    </section>
+    <section id="telegraph">
+        <h3>The Daily Telegraph</h3>
+        <p>Holmes places a classified ad to lure the conspirators into revealing themselves.</p>
+    </section>
+    <section id="charing-cross">
+        <h3>Charing Cross Hotel</h3>
+        <p>The sting at Charing Cross Hotel succeeds, apprehending the culprits behind the stolen plans.</p>
+    </section>
+    """.strip()
+
+    chapters_js = "\n".join(
+        [
+            "const chapters = {",
+            "    'baker': { bearing: 27, center: [-0.15591514, 51.51830379], zoom: 15.5, pitch: 20 },",
+            "    'aldgate': { duration: 6000, center: [-0.07571203, 51.51424049], bearing: 150, zoom: 15, pitch: 0 },",
+            "    'london-bridge': { bearing: 90, center: [-0.08533793, 51.50438536], zoom: 13, speed: 0.6, pitch: 40 },",
+            "    'woolwich': { bearing: 90, center: [0.05991101, 51.48752939], zoom: 12.3 },",
+            "    'gloucester': { bearing: 45, center: [-0.18335806, 51.49439521], zoom: 15.3, pitch: 20, speed: 0.5 },",
+            "    'caulfield-gardens': { bearing: 180, center: [-0.19684993, 51.5033856], zoom: 12.3 },",
+            "    'telegraph': { bearing: 90, center: [-0.10669358, 51.51433123], zoom: 17.3, pitch: 40 },",
+            "    'charing-cross': { bearing: 90, center: [-0.12416858, 51.50779757], zoom: 14.3, pitch: 20 }",
+            "};",
+        ]
+    )
+
+    scroll_js = "\n".join(
+        [
+            "const story = document.createElement('div');",
+            "story.id = 'features';",
+            "story.className = 'maplibreum-story';",
+            f"story.innerHTML = `{story_html}`;",
+            "document.body.appendChild(story);",
+            chapters_js,
+            "window.onscroll = function () {",
+            "    const chapterNames = Object.keys(chapters);",
+            "    for (let i = 0; i < chapterNames.length; i++) {",
+            "        const chapterName = chapterNames[i];",
+            "        if (isElementOnScreen(chapterName)) {",
+            "            setActiveChapter(chapterName);",
+            "            break;",
+            "        }",
+            "    }",
+            "};",
+            "let activeChapterName = 'baker';",
+            "function setActiveChapter(chapterName) {",
+            "    if (chapterName === activeChapterName) return;",
+            "    map.flyTo(chapters[chapterName]);",
+            "    document.getElementById(chapterName).classList.add('active');",
+            "    document.getElementById(activeChapterName).classList.remove('active');",
+            "    activeChapterName = chapterName;",
+            "}",
+            "function isElementOnScreen(id) {",
+            "    const element = document.getElementById(id);",
+            "    const bounds = element.getBoundingClientRect();",
+            "    return bounds.top < window.innerHeight && bounds.bottom > 0;",
+            "}",
+        ]
+    )
+
+    m.add_on_load_js(scroll_js)
+
+    html = m.render()
+
+    assert '"style": "https://tiles.openfreemap.org/styles/bright"' in html
+    assert '"center": [-0.15591514, 51.51830379]' in html
+    assert '"zoom": 15.5' in html
+    assert '"bearing": 27' in html
+    assert '"pitch": 45' in html
+    assert "map.flyTo(chapters[chapterName]);" in html
+    assert "window.onscroll" in html

--- a/tests/test_examples/test_jump_to_a_series_of_locations.py
+++ b/tests/test_examples/test_jump_to_a_series_of_locations.py
@@ -1,0 +1,48 @@
+"""Parity test for the jump-to-a-series-of-locations example."""
+
+import json
+
+from maplibreum.core import Map
+
+
+def test_jump_to_a_series_of_locations():
+    cities = {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [100.507, 13.745]}},
+            {"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [98.993, 18.793]}},
+            {"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [99.838, 19.924]}},
+            {"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [102.812, 17.408]}},
+            {"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [100.458, 7.001]}},
+            {"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [100.905, 12.935]}},
+        ],
+    }
+
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[100.507, 13.745],
+        zoom=9,
+    )
+
+    cities_js = json.dumps(cities)
+
+    m.add_on_load_js(
+        "\n".join(
+            [
+                f"const cities = {cities_js};",
+                "cities.features.forEach((city, index) => {",
+                "    setTimeout(() => {",
+                "        map.jumpTo({center: city.geometry.coordinates});",
+                "    }, 2000 * index);",
+                "});",
+            ]
+        )
+    )
+
+    html = m.render()
+
+    assert '"style": "https://tiles.openfreemap.org/styles/bright"' in html
+    assert '"center": [100.507, 13.745]' in html
+    assert '"zoom": 9' in html
+    assert "setTimeout(() => {" in html
+    assert "map.jumpTo({center: city.geometry.coordinates});" in html

--- a/tests/test_examples/test_offset_the_vanishing_point_using_padding.py
+++ b/tests/test_examples/test_offset_the_vanishing_point_using_padding.py
@@ -1,0 +1,89 @@
+"""Parity test for the offset-the-vanishing-point-using-padding example."""
+
+from maplibreum.core import Map
+
+
+def test_offset_the_vanishing_point_using_padding():
+    sidebar_css = "\n".join(
+        [
+            ".rounded-rect { background: white; border-radius: 10px; box-shadow: 0 0 50px -25px black; }",
+            ".flex-center { position: absolute; display: flex; justify-content: center; align-items: center; }",
+            ".flex-center.left { left: 0; }",
+            ".flex-center.right { right: 0; }",
+            ".sidebar-content { position: absolute; width: 95%; height: 95%; font-family: Arial, Helvetica, sans-serif; font-size: 32px; color: gray; }",
+            ".sidebar-toggle { position: absolute; width: 1.3em; height: 1.3em; display: flex; justify-content: center; align-items: center; cursor: pointer; }",
+            ".sidebar-toggle.left { right: -1.5em; }",
+            ".sidebar-toggle.right { left: -1.5em; }",
+            ".sidebar { transition: transform 1s; z-index: 1; width: 300px; height: 100%; }",
+            ".left.collapsed { transform: translateX(-295px); }",
+            ".right.collapsed { transform: translateX(295px); }",
+        ]
+    )
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-77.01866, 38.888],
+        zoom=4,
+        pitch=60,
+        custom_css=sidebar_css,
+    )
+
+    m.add_marker(coordinates=[-77.01866, 38.888])
+
+    container_id = m.map_id
+
+    sidebar_js = "\n".join(
+        [
+            f"const mapContainer = document.getElementById('{container_id}');",
+            "const leftSidebar = document.createElement('div');",
+            "leftSidebar.id = 'left';",
+            "leftSidebar.className = 'sidebar flex-center left collapsed';",
+            "leftSidebar.innerHTML = `",
+            "    <div class=\"sidebar-content rounded-rect flex-center\">",
+            "        Left Sidebar",
+            "        <div class=\"sidebar-toggle rounded-rect left\">&rarr;</div>",
+            "    </div>",
+            "`;",
+            "const rightSidebar = document.createElement('div');",
+            "rightSidebar.id = 'right';",
+            "rightSidebar.className = 'sidebar flex-center right collapsed';",
+            "rightSidebar.innerHTML = `",
+            "    <div class=\"sidebar-content rounded-rect flex-center\">",
+            "        Right Sidebar",
+            "        <div class=\"sidebar-toggle rounded-rect right\">&larr;</div>",
+            "    </div>",
+            "`;",
+            "mapContainer.appendChild(leftSidebar);",
+            "mapContainer.appendChild(rightSidebar);",
+            "function toggleSidebar(id) {",
+            "    const elem = document.getElementById(id);",
+            "    const classes = elem.className.split(' ');",
+            "    const collapsed = classes.indexOf('collapsed') !== -1;",
+            "    const padding = {};",
+            "    if (collapsed) {",
+            "        classes.splice(classes.indexOf('collapsed'), 1);",
+            "        padding[id] = 300;",
+            "        map.easeTo({ padding, duration: 1000 });",
+            "    } else {",
+            "        padding[id] = 0;",
+            "        classes.push('collapsed');",
+            "        map.easeTo({ padding, duration: 1000 });",
+            "    }",
+            "    elem.className = classes.join(' ');",
+            "}",
+            "leftSidebar.querySelector('.sidebar-toggle').addEventListener('click', () => toggleSidebar('left'));",
+            "rightSidebar.querySelector('.sidebar-toggle').addEventListener('click', () => toggleSidebar('right'));",
+            "toggleSidebar('left');",
+        ]
+    )
+
+    m.add_on_load_js(sidebar_js)
+
+    html = m.render()
+
+    assert '"style": "https://demotiles.maplibre.org/style.json"' in html
+    assert '"center": [-77.01866, 38.888]' in html
+    assert '"zoom": 4' in html
+    assert '"pitch": 60' in html
+    assert "map.easeTo({ padding, duration: 1000 });" in html
+    assert "padding[id] = 300" in html

--- a/tests/test_examples/test_slowly_fly_to_a_location.py
+++ b/tests/test_examples/test_slowly_fly_to_a_location.py
@@ -1,0 +1,69 @@
+"""Parity test for the slowly-fly-to-a-location MapLibre example."""
+
+from maplibreum.core import Map
+
+
+def test_slowly_fly_to_a_location():
+    button_css = """
+    .maplibreum-slow-fly {
+        display: block;
+        position: absolute;
+        top: 20px;
+        left: 50%;
+        transform: translate(-50%);
+        width: 50%;
+        height: 40px;
+        padding: 10px;
+        border: none;
+        border-radius: 3px;
+        font-size: 12px;
+        text-align: center;
+        color: #fff;
+        background: #ee8a65;
+        cursor: pointer;
+    }
+    """.strip()
+
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-74.5, 40],
+        zoom=9,
+        custom_css=button_css,
+    )
+
+    m.add_on_load_js(
+        "\n".join(
+            [
+                "const start = [-74.5, 40];",
+                "const end = [74.5, 40];",
+                "let isAtStart = true;",
+                "const slowFly = document.createElement('button');",
+                "slowFly.id = 'fly';",
+                "slowFly.className = 'maplibreum-slow-fly';",
+                "slowFly.textContent = 'Fly';",
+                "document.body.appendChild(slowFly);",
+                "slowFly.addEventListener('click', () => {",
+                "    const target = isAtStart ? end : start;",
+                "    isAtStart = !isAtStart;",
+                "    map.flyTo({",
+                "        center: target,",
+                "        zoom: 9,",
+                "        bearing: 0,",
+                "        speed: 0.2,",
+                "        curve: 1,",
+                "        easing(t) { return t; },",
+                "        essential: true",
+                "    });",
+                "});",
+            ]
+        )
+    )
+
+    html = m.render()
+
+    assert '"style": "https://tiles.openfreemap.org/styles/bright"' in html
+    assert '"center": [-74.5, 40]' in html
+    assert '"zoom": 9' in html
+    assert "speed: 0.2" in html
+    assert "curve: 1" in html
+    assert "easing(t) { return t; }" in html


### PR DESCRIPTION
## Summary
- add pytest modules mirroring the animated MapLibre examples for markers, points, camera movement, and fly-to flows
- inject supporting DOM overlays, event handlers, and animation loops to replicate the original JavaScript behaviour
- update status.json to mark the examples as reproduced

## Testing
- pytest tests/test_examples -k "animate or center_the_map or customize_camera or fit_to_the_bounds or fly_to or jump_to or offset_the_vanishing_point"

------
https://chatgpt.com/codex/tasks/task_b_68d725a543c4832f8f014c791ba372ee