### PR TITLE
Add parity tests for interaction MapLibre examples

### DIFF
--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -348,8 +348,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-draggable-point/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/create-a-draggable-point.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_create_a_draggable_point.py"
     },
     "create-a-gradient-line-using-an-expression": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-gradient-line-using-an-expression/",
@@ -376,8 +376,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-hover-effect/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/create-a-hover-effect.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_create_a_hover_effect.py"
     },
     "create-a-time-slider": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-time-slider/",
@@ -642,15 +642,15 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/get-coordinates-of-the-mouse-pointer/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/get-coordinates-of-the-mouse-pointer.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_get_coordinates_of_the_mouse_pointer.py"
     },
     "get-features-under-the-mouse-pointer": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/get-features-under-the-mouse-pointer/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/get-features-under-the-mouse-pointer.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_get_features_under_the_mouse_pointer.py"
     },
     "hash-routing": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/hash-routing/",
@@ -684,15 +684,15 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/measure-distances/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/measure-distances.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_measure_distances.py"
     },
     "navigate-the-map-with-game-like-controls": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/navigate-the-map-with-game-like-controls/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/navigate-the-map-with-game-like-controls.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_navigate_the_map_with_game_like_controls.py"
     },
     "offset-the-vanishing-point-using-padding": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/offset-the-vanishing-point-using-padding/",
@@ -719,8 +719,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/restrict-map-panning-to-an-area/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/restrict-map-panning-to-an-area.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_restrict_map_panning_to_an_area.py"
     },
     "set-center-point-above-ground": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/set-center-point-above-ground/",
@@ -768,8 +768,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/sync-movement-of-multiple-maps/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/sync-movement-of-multiple-maps.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_sync_movement_of_multiple_maps.py"
     },
     "toggle-deckgl-layer": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-deckgl-layer/",
@@ -782,8 +782,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-interactions/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/toggle-interactions.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_toggle_interactions.py"
     },
     "update-a-feature-in-realtime": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/update-a-feature-in-realtime/",

--- a/tests/test_examples/test_create_a_draggable_point.py
+++ b/tests/test_examples/test_create_a_draggable_point.py
@@ -1,0 +1,193 @@
+"""Parity test for the create-a-draggable-point MapLibre example."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+
+from maplibreum.core import Map
+
+
+def test_create_a_draggable_point() -> None:
+    """Allow a circle feature to be dragged while updating its coordinates display."""
+
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [0, 0]},
+            }
+        ],
+    }
+
+    map_instance = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[0, 0],
+        zoom=2,
+    )
+
+    map_instance.custom_css = textwrap.dedent(
+        """
+        .maplibreum-draggable-coordinates {
+            background: rgba(0, 0, 0, 0.5);
+            color: #fff;
+            position: absolute;
+            bottom: 40px;
+            left: 10px;
+            padding: 5px 10px;
+            margin: 0;
+            font-size: 11px;
+            line-height: 18px;
+            border-radius: 3px;
+            display: none;
+        }
+        """
+    ).strip()
+
+    map_instance.add_source("point", {"type": "geojson", "data": geojson})
+    map_instance.add_circle_layer(
+        "point",
+        "point",
+        paint={"circle-radius": 10, "circle-color": "#3887be"},
+    )
+
+    setup_js = textwrap.dedent(
+        f"""
+        var coordinatesElement = document.createElement('pre');
+        coordinatesElement.id = 'coordinates';
+        coordinatesElement.className = 'maplibreum-draggable-coordinates';
+        coordinatesElement.style.display = 'none';
+        map.getContainer().appendChild(coordinatesElement);
+
+        window._maplibreumDragDetails = {{
+            element: coordinatesElement,
+            active: false,
+            lastCoords: null,
+            data: {json.dumps(geojson)}
+        }};
+
+        var dragSource = map.getSource('point');
+        if (dragSource) {{
+            dragSource.setData(window._maplibreumDragDetails.data);
+        }}
+        """
+    ).strip()
+    map_instance.add_on_load_js(setup_js)
+
+    map_instance.add_event_listener(
+        "mouseenter",
+        layer_id="point",
+        js=textwrap.dedent(
+            """
+            map.setPaintProperty('point', 'circle-color', '#3bb2d0');
+            map.getCanvas().style.cursor = 'move';
+            """
+        ).strip(),
+    )
+
+    map_instance.add_event_listener(
+        "mouseleave",
+        layer_id="point",
+        js=textwrap.dedent(
+            """
+            map.setPaintProperty('point', 'circle-color', '#3887be');
+            map.getCanvas().style.cursor = '';
+            """
+        ).strip(),
+    )
+
+    map_instance.add_event_listener(
+        "mousedown",
+        layer_id="point",
+        js=textwrap.dedent(
+            """
+            event.preventDefault();
+            var details = window._maplibreumDragDetails;
+            if (!details) { return; }
+            details.active = true;
+            details.lastCoords = event.lngLat || null;
+            map.getCanvas().style.cursor = 'grab';
+            """
+        ).strip(),
+    )
+
+    map_instance.add_event_listener(
+        "touchstart",
+        layer_id="point",
+        js=textwrap.dedent(
+            """
+            if (event.points && event.points.length !== 1) { return; }
+            event.preventDefault();
+            var details = window._maplibreumDragDetails;
+            if (!details) { return; }
+            details.active = true;
+            details.lastCoords = event.lngLat || null;
+            map.getCanvas().style.cursor = 'grab';
+            """
+        ).strip(),
+    )
+
+    drag_update_js = textwrap.dedent(
+        """
+        var details = window._maplibreumDragDetails;
+        if (!details || !details.active) { return; }
+        if (!event.lngLat) { return; }
+        details.lastCoords = event.lngLat;
+        var dragSource = map.getSource('point');
+        if (!dragSource) { return; }
+        details.data.features[0].geometry.coordinates = [event.lngLat.lng, event.lngLat.lat];
+        dragSource.setData(details.data);
+        map.getCanvas().style.cursor = 'grabbing';
+        """
+    ).strip()
+
+    map_instance.add_event_listener("mousemove", js=drag_update_js)
+    map_instance.add_event_listener("touchmove", js=drag_update_js)
+
+    release_js = textwrap.dedent(
+        """
+        var details = window._maplibreumDragDetails;
+        if (!details || !details.active) { return; }
+        var coords = event.lngLat || details.lastCoords;
+        if (coords) {
+            details.element.style.display = 'block';
+            details.element.innerHTML = 'Longitude: ' + coords.lng + '<br />Latitude: ' + coords.lat;
+        }
+        details.active = false;
+        map.getCanvas().style.cursor = '';
+        """
+    ).strip()
+
+    map_instance.add_event_listener("mouseup", js=release_js)
+    map_instance.add_event_listener("touchend", js=release_js)
+
+    source_lookup = {source["name"]: source["definition"] for source in map_instance.sources}
+    assert "point" in source_lookup
+    assert source_lookup["point"]["type"] == "geojson"
+    assert source_lookup["point"]["data"] == geojson
+
+    layer_definition = next(layer for layer in map_instance.layers if layer["id"] == "point")
+    assert layer_definition["definition"]["type"] == "circle"
+    assert layer_definition["definition"]["paint"]["circle-radius"] == 10
+    assert layer_definition["definition"]["paint"]["circle-color"] == "#3887be"
+
+    events = {binding.id: binding for binding in map_instance.event_bindings}
+    assert "mouseenter@point" in events
+    assert "mouseleave@point" in events
+    assert "mousedown@point" in events
+    assert "touchstart@point" in events
+    assert "mousemove" in events
+    assert "touchmove" in events
+    assert "mouseup" in events
+    assert "touchend" in events
+
+    assert "setPaintProperty" in events["mouseenter@point"].js
+    assert "details.active" in events["mousedown@point"].js
+    assert "dragSource.setData" in events["mousemove"].js
+    assert "details.element.style.display = 'block'" in events["mouseup"].js
+
+    html = map_instance.render()
+    assert "maplibreum-draggable-coordinates" in html
+    assert "window._maplibreumDragDetails" in html
+    assert "Longitude:" in html

--- a/tests/test_examples/test_create_a_hover_effect.py
+++ b/tests/test_examples/test_create_a_hover_effect.py
@@ -1,0 +1,109 @@
+"""Parity test for the create-a-hover-effect MapLibre example."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum.core import Map
+
+
+def test_create_a_hover_effect() -> None:
+    """Toggle feature state for hovered polygons using a GeoJSON source."""
+
+    map_instance = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-100.486052, 37.830348],
+        zoom=2,
+    )
+
+    map_instance.add_source(
+        "states",
+        {
+            "type": "geojson",
+            "data": "https://maplibre.org/maplibre-gl-js/docs/assets/us_states.geojson",
+        },
+    )
+
+    map_instance.add_fill_layer(
+        "state-fills",
+        "states",
+        paint={
+            "fill-color": "#627BC1",
+            "fill-opacity": [
+                "case",
+                ["boolean", ["feature-state", "hover"], False],
+                1,
+                0.5,
+            ],
+        },
+    )
+
+    map_instance.add_layer(
+        {
+            "id": "state-borders",
+            "type": "line",
+            "source": "states",
+            "layout": {},
+            "paint": {"line-color": "#627BC1", "line-width": 2},
+        }
+    )
+
+    map_instance.add_on_load_js("window._maplibreumHoverStateId = null;")
+
+    move_js = textwrap.dedent(
+        """
+        var hoveredStateId = window._maplibreumHoverStateId;
+        var features = event.features || [];
+        if (!features.length) { return; }
+        var nextStateId = features[0].id;
+        if (hoveredStateId !== null && hoveredStateId !== undefined && hoveredStateId !== nextStateId) {
+            map.setFeatureState({ source: 'states', id: hoveredStateId }, { hover: false });
+        }
+        window._maplibreumHoverStateId = nextStateId;
+        map.setFeatureState({ source: 'states', id: nextStateId }, { hover: true });
+        """
+    ).strip()
+
+    map_instance.add_event_listener(
+        "mousemove",
+        layer_id="state-fills",
+        js=move_js,
+    )
+
+    leave_js = textwrap.dedent(
+        """
+        var hoveredStateId = window._maplibreumHoverStateId;
+        if (hoveredStateId !== null && hoveredStateId !== undefined) {
+            map.setFeatureState({ source: 'states', id: hoveredStateId }, { hover: false });
+        }
+        window._maplibreumHoverStateId = null;
+        """
+    ).strip()
+
+    map_instance.add_event_listener(
+        "mouseleave",
+        layer_id="state-fills",
+        js=leave_js,
+    )
+
+    source_lookup = {source["name"]: source["definition"] for source in map_instance.sources}
+    assert source_lookup["states"]["data"].endswith("us_states.geojson")
+
+    fill_layer = next(layer for layer in map_instance.layers if layer["id"] == "state-fills")
+    assert fill_layer["definition"]["type"] == "fill"
+    assert fill_layer["definition"]["paint"]["fill-color"] == "#627BC1"
+    assert fill_layer["definition"]["paint"]["fill-opacity"][0] == "case"
+
+    border_layer = next(layer for layer in map_instance.layers if layer["id"] == "state-borders")
+    assert border_layer["definition"]["type"] == "line"
+    assert border_layer["definition"]["paint"]["line-width"] == 2
+
+    bindings = {binding.id: binding for binding in map_instance.event_bindings}
+    assert "mousemove@state-fills" in bindings
+    assert "mouseleave@state-fills" in bindings
+    assert "setFeatureState" in bindings["mousemove@state-fills"].js
+    assert "window._maplibreumHoverStateId" in bindings["mouseleave@state-fills"].js
+
+    html = map_instance.render()
+    assert "window._maplibreumHoverStateId" in html
+    assert "setFeatureState" in html

--- a/tests/test_examples/test_get_coordinates_of_the_mouse_pointer.py
+++ b/tests/test_examples/test_get_coordinates_of_the_mouse_pointer.py
@@ -1,0 +1,74 @@
+"""Parity test for the get-coordinates-of-the-mouse-pointer example."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum.core import Map
+
+
+def test_get_coordinates_of_the_mouse_pointer() -> None:
+    """Display both pixel and geographic coordinates while the mouse moves."""
+
+    map_instance = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-74.5, 40.0],
+        zoom=3,
+    )
+
+    map_instance.custom_css = textwrap.dedent(
+        """
+        .maplibreum-pointer-info {
+            display: block;
+            position: absolute;
+            top: 20px;
+            left: 50%;
+            transform: translate(-50%);
+            width: 50%;
+            padding: 10px;
+            border-radius: 3px;
+            font-size: 12px;
+            text-align: center;
+            color: #222;
+            background: #fff;
+        }
+        """
+    ).strip()
+
+    setup_js = textwrap.dedent(
+        """
+        var info = document.createElement('pre');
+        info.id = 'maplibreum-pointer-info';
+        info.className = 'maplibreum-pointer-info';
+        map.getContainer().appendChild(info);
+        window._maplibreumPointerInfo = info;
+        """
+    ).strip()
+
+    map_instance.add_on_load_js(setup_js)
+
+    move_js = textwrap.dedent(
+        """
+        var info = window._maplibreumPointerInfo || document.getElementById('maplibreum-pointer-info');
+        if (!info) { return; }
+        var pointString = event.point ? JSON.stringify(event.point) : '';
+        var lngLatString = '';
+        if (event.lngLat && typeof event.lngLat.wrap === 'function') {
+            lngLatString = JSON.stringify(event.lngLat.wrap());
+        } else if (event.lngLat) {
+            lngLatString = JSON.stringify(event.lngLat);
+        }
+        info.innerHTML = pointString + '<br />' + lngLatString;
+        """
+    ).strip()
+
+    map_instance.add_event_listener("mousemove", js=move_js)
+
+    binding = map_instance.event_bindings[0]
+    assert binding.event == "mousemove"
+    assert "JSON.stringify(event.point)" in binding.js
+    assert "event.lngLat.wrap" in binding.js
+
+    html = map_instance.render()
+    assert "maplibreum-pointer-info" in html
+    assert "JSON.stringify(event.point)" in html

--- a/tests/test_examples/test_get_features_under_the_mouse_pointer.py
+++ b/tests/test_examples/test_get_features_under_the_mouse_pointer.py
@@ -1,0 +1,73 @@
+"""Parity test for the get-features-under-the-mouse-pointer example."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum.core import Map
+
+
+def test_get_features_under_the_mouse_pointer() -> None:
+    """Query rendered features and list their key properties while hovering."""
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-96, 37.8],
+        zoom=3,
+    )
+
+    map_instance.custom_css = textwrap.dedent(
+        f"""
+        .maplibreum-feature-list {{
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            width: 50%;
+            overflow: auto;
+            background: rgba(255, 255, 255, 0.8);
+        }}
+        #{map_instance.map_id} canvas {{
+            cursor: crosshair;
+        }}
+        """
+    ).strip()
+
+    setup_js = textwrap.dedent(
+        """
+        var featureList = document.createElement('pre');
+        featureList.id = 'maplibreum-feature-list';
+        featureList.className = 'maplibreum-feature-list';
+        map.getContainer().appendChild(featureList);
+        window._maplibreumFeatureList = featureList;
+        """
+    ).strip()
+
+    map_instance.add_on_load_js(setup_js)
+
+    move_js = textwrap.dedent(
+        """
+        var output = window._maplibreumFeatureList || document.getElementById('maplibreum-feature-list');
+        if (!output) { return; }
+        var features = map.queryRenderedFeatures(event.point);
+        var displayProperties = ['type', 'properties', 'id', 'layer', 'source', 'sourceLayer', 'state'];
+        var subset = features.map(function(feature) {
+            var info = {};
+            displayProperties.forEach(function(prop) {
+                info[prop] = feature[prop];
+            });
+            return info;
+        });
+        output.innerHTML = JSON.stringify(subset, null, 2);
+        """
+    ).strip()
+
+    map_instance.add_event_listener("mousemove", js=move_js)
+
+    binding = map_instance.event_bindings[0]
+    assert "queryRenderedFeatures" in binding.js
+    assert "displayProperties" in binding.js
+
+    html = map_instance.render()
+    assert "maplibreum-feature-list" in html
+    assert "queryRenderedFeatures" in html

--- a/tests/test_examples/test_measure_distances.py
+++ b/tests/test_examples/test_measure_distances.py
@@ -1,0 +1,163 @@
+"""Parity test for the measure-distances MapLibre example."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+
+from maplibreum.core import Map
+
+
+def test_measure_distances() -> None:
+    """Allow users to measure distances by clicking points on the map."""
+
+    measurement_data = {"type": "FeatureCollection", "features": []}
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[2.3399, 48.8555],
+        zoom=12,
+    )
+
+    map_instance.custom_css = textwrap.dedent(
+        """
+        .maplibreum-distance-container {
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            z-index: 1;
+        }
+
+        .maplibreum-distance-container > * {
+            background-color: rgba(0, 0, 0, 0.5);
+            color: #fff;
+            font-size: 11px;
+            line-height: 18px;
+            display: block;
+            margin: 0;
+            padding: 5px 10px;
+            border-radius: 3px;
+        }
+        """
+    ).strip()
+
+    map_instance.add_external_script("https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js")
+
+    map_instance.add_source("measurements", {"type": "geojson", "data": measurement_data})
+
+    map_instance.add_circle_layer(
+        "measure-points",
+        "measurements",
+        paint={"circle-radius": 5, "circle-color": "#000"},
+        filter=["in", "$type", "Point"],
+    )
+
+    map_instance.add_layer(
+        {
+            "id": "measure-lines",
+            "type": "line",
+            "source": "measurements",
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {"line-color": "#000", "line-width": 2.5},
+            "filter": ["in", "$type", "LineString"],
+        }
+    )
+
+    setup_js = textwrap.dedent(
+        f"""
+        var distanceContainer = document.createElement('div');
+        distanceContainer.id = 'maplibreum-distance';
+        distanceContainer.className = 'maplibreum-distance-container';
+        map.getContainer().appendChild(distanceContainer);
+
+        window._maplibreumMeasure = {{
+            container: distanceContainer,
+            geojson: {json.dumps(measurement_data)},
+            line: {{
+                type: 'Feature',
+                geometry: {{ type: 'LineString', coordinates: [] }}
+            }}
+        }};
+
+        var measureSource = map.getSource('measurements');
+        if (measureSource) {{
+            measureSource.setData(window._maplibreumMeasure.geojson);
+        }}
+        """
+    ).strip()
+
+    map_instance.add_on_load_js(setup_js)
+
+    click_js = textwrap.dedent(
+        """
+        var measure = window._maplibreumMeasure;
+        if (!measure) { return; }
+        var geojson = measure.geojson;
+        var clickedFeatures = map.queryRenderedFeatures(event.point, { layers: ['measure-points'] });
+
+        if (geojson.features.length > 1) {
+            geojson.features.pop();
+        }
+
+        measure.container.innerHTML = '';
+
+        if (clickedFeatures.length) {
+            var targetId = clickedFeatures[0].properties && clickedFeatures[0].properties.id;
+            geojson.features = geojson.features.filter(function(point) {
+                return point.properties && point.properties.id !== targetId;
+            });
+        } else if (event.lngLat) {
+            geojson.features.push({
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [event.lngLat.lng, event.lngLat.lat] },
+                properties: { id: String(Date.now()) }
+            });
+        }
+
+        if (geojson.features.length > 1) {
+            measure.line.geometry.coordinates = geojson.features.map(function(point) {
+                return point.geometry.coordinates;
+            });
+            geojson.features.push(measure.line);
+            var value = document.createElement('pre');
+            if (typeof turf !== 'undefined' && turf.length) {
+                var km = turf.length(measure.line);
+                value.textContent = 'Total distance: ' + km.toLocaleString() + 'km';
+            } else {
+                value.textContent = 'Total distance: unavailable';
+            }
+            measure.container.appendChild(value);
+        }
+
+        var source = map.getSource('measurements');
+        if (source) {
+            source.setData(geojson);
+        }
+        """
+    ).strip()
+
+    map_instance.add_event_listener("click", js=click_js)
+
+    cursor_js = textwrap.dedent(
+        """
+        var features = map.queryRenderedFeatures(event.point, { layers: ['measure-points'] });
+        map.getCanvas().style.cursor = features.length ? 'pointer' : 'crosshair';
+        """
+    ).strip()
+
+    map_instance.add_event_listener("mousemove", js=cursor_js)
+
+    assert any(
+        script["src"] == "https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js"
+        for script in map_instance.external_scripts
+    )
+
+    bindings = {binding.id: binding for binding in map_instance.event_bindings}
+    assert "click" in bindings
+    assert "queryRenderedFeatures" in bindings["click"].js
+    assert "turf.length" in bindings["click"].js
+    assert "cursor" in bindings["mousemove"].js
+
+    html = map_instance.render()
+    assert "Total distance:" in html
+    assert "@turf/turf" in html

--- a/tests/test_examples/test_navigate_the_map_with_game_like_controls.py
+++ b/tests/test_examples/test_navigate_the_map_with_game_like_controls.py
@@ -1,0 +1,64 @@
+"""Parity test for the navigate-the-map-with-game-like-controls example."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum.core import Map
+
+
+def test_navigate_the_map_with_game_like_controls() -> None:
+    """Register keyboard interactions that pan or rotate the map."""
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/liberty",
+        center=[-87.6298, 41.8781],
+        zoom=19,
+        bearing=-12,
+        pitch=60,
+        map_options={"interactive": False},
+    )
+
+    control_js = textwrap.dedent(
+        """
+        var canvas = map.getCanvas();
+        if (!canvas) { return; }
+        if (!canvas.hasAttribute('tabindex')) {
+            canvas.setAttribute('tabindex', '0');
+        }
+        canvas.focus();
+
+        var deltaDistance = 100;
+        var deltaDegrees = 25;
+
+        function easing(t) {
+            return t * (2 - t);
+        }
+
+        canvas.addEventListener('keydown', function(e) {
+            e.preventDefault();
+            if (e.which === 38) {
+                map.panBy([0, -deltaDistance], { easing: easing });
+            } else if (e.which === 40) {
+                map.panBy([0, deltaDistance], { easing: easing });
+            } else if (e.which === 37) {
+                map.easeTo({ bearing: map.getBearing() - deltaDegrees, easing: easing });
+            } else if (e.which === 39) {
+                map.easeTo({ bearing: map.getBearing() + deltaDegrees, easing: easing });
+            }
+        }, true);
+        """
+    ).strip()
+
+    map_instance.add_on_load_js(control_js)
+
+    assert map_instance.center == [-87.6298, 41.8781]
+    assert map_instance.zoom == 19
+    assert map_instance.bearing == -12
+    assert map_instance.pitch == 60
+    assert map_instance.additional_map_options["interactive"] is False
+
+    html = map_instance.render()
+    assert "deltaDistance = 100" in html
+    assert "map.panBy([0, -deltaDistance]" in html
+    assert "map.easeTo({ bearing: map.getBearing() - deltaDegrees" in html

--- a/tests/test_examples/test_restrict_map_panning_to_an_area.py
+++ b/tests/test_examples/test_restrict_map_panning_to_an_area.py
@@ -1,0 +1,29 @@
+"""Parity test for the restrict-map-panning-to-an-area example."""
+
+from __future__ import annotations
+
+from maplibreum.core import Map
+
+
+def test_restrict_map_panning_to_an_area() -> None:
+    """Configure a map with max bounds covering New York City."""
+
+    bounds = [
+        [-74.04728500751165, 40.68392799015035],
+        [-73.91058699000139, 40.87764500765852],
+    ]
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-73.9978, 40.7209],
+        zoom=13,
+        map_options={"maxBounds": bounds},
+    )
+
+    assert map_instance.center == [-73.9978, 40.7209]
+    assert map_instance.zoom == 13
+    assert map_instance.additional_map_options["maxBounds"] == bounds
+
+    html = map_instance.render()
+    assert "maxBounds" in html
+    assert "-74.04728500751165" in html

--- a/tests/test_examples/test_sync_movement_of_multiple_maps.py
+++ b/tests/test_examples/test_sync_movement_of_multiple_maps.py
@@ -1,0 +1,105 @@
+"""Parity test for the sync-movement-of-multiple-maps example."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum.core import Map
+
+
+def test_sync_movement_of_multiple_maps() -> None:
+    """Instantiate three MapLibre maps and synchronise their viewpoints."""
+
+    map_instance = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[0, 0],
+        zoom=1,
+        map_options={"maplibreLogo": True},
+        width="100%",
+        height="500px",
+    )
+
+    map_instance.custom_css = textwrap.dedent(
+        f"""
+        html, body {{
+            height: 100%;
+        }}
+        .maplibreum-sync-wrapper {{
+            display: flex;
+            width: 100%;
+            height: 100%;
+        }}
+        .maplibreum-sync-wrapper > .maplibreum-sync-map {{
+            flex: 1 1 0;
+            height: 100%;
+        }}
+        #{map_instance.map_id} {{
+            height: 100%;
+        }}
+        """
+    ).strip()
+
+    map_instance.add_external_script("https://unpkg.com/@mapbox/mapbox-gl-sync-move@0.3.1")
+
+    sync_js = textwrap.dedent(
+        f"""
+        var primaryContainer = document.getElementById('{map_instance.map_id}');
+        if (!primaryContainer) {{ return; }}
+
+        var wrapper = document.createElement('div');
+        wrapper.className = 'maplibreum-sync-wrapper';
+        primaryContainer.parentNode.insertBefore(wrapper, primaryContainer);
+        wrapper.appendChild(primaryContainer);
+        primaryContainer.classList.add('maplibreum-sync-map');
+
+        var mapIds = ['{map_instance.map_id}', '{map_instance.map_id}-secondary', '{map_instance.map_id}-tertiary'];
+        for (var i = 1; i < mapIds.length; i++) {{
+            var div = document.createElement('div');
+            div.id = mapIds[i];
+            div.className = 'maplibreum-sync-map';
+            wrapper.appendChild(div);
+        }}
+
+        var map2 = new maplibregl.Map({{
+            container: mapIds[1],
+            style: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+            center: [0, 0],
+            zoom: 1,
+            maplibreLogo: true
+        }});
+
+        var map3 = new maplibregl.Map({{
+            container: mapIds[2],
+            style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+            center: [0, 0],
+            zoom: 1,
+            maplibreLogo: true
+        }});
+
+        if (typeof syncMaps === 'function') {{
+            syncMaps(map, map2, map3);
+        }}
+
+        window._maplibreumSyncedMaps = [map, map2, map3];
+        window._maplibreumSyncedCenter = map.getCenter();
+
+        function updateCenter(sourceMap) {{
+            window._maplibreumSyncedCenter = sourceMap.getCenter();
+        }}
+
+        map.on('move', function() {{ updateCenter(map); }});
+        map2.on('move', function() {{ updateCenter(map2); }});
+        map3.on('move', function() {{ updateCenter(map3); }});
+        """
+    ).strip()
+
+    map_instance.add_on_load_js(sync_js)
+
+    assert map_instance.center == [0, 0]
+    assert map_instance.zoom == 1
+    assert map_instance.additional_map_options["maplibreLogo"] is True
+
+    html = map_instance.render()
+    assert "syncMaps(map, map2, map3)" in html
+    assert "mapbox-gl-sync-move" in html
+    assert "window._maplibreumSyncedMaps" in html

--- a/tests/test_examples/test_toggle_interactions.py
+++ b/tests/test_examples/test_toggle_interactions.py
@@ -1,0 +1,113 @@
+"""Parity test for the toggle-interactions MapLibre example."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum.core import Map
+
+
+def test_toggle_interactions() -> None:
+    """Expose checkboxes that enable or disable standard map handlers."""
+
+    map_instance = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-77.04, 38.907],
+        zoom=3,
+    )
+
+    map_instance.custom_css = textwrap.dedent(
+        """
+        .listing-group {
+            font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+            font-weight: 600;
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            z-index: 1;
+            border-radius: 3px;
+            max-width: 20%;
+            color: #fff;
+        }
+
+        .listing-group input[type='checkbox'] {
+            display: none;
+        }
+
+        .listing-group input[type='checkbox'] + label {
+            background-color: #3386c0;
+            display: block;
+            cursor: pointer;
+            padding: 10px;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+            text-transform: capitalize;
+        }
+
+        .listing-group input[type='checkbox']:first-child + label {
+            border-radius: 3px 3px 0 0;
+        }
+
+        .listing-group label:last-child {
+            border-radius: 0 0 3px 3px;
+            border: none;
+        }
+
+        .listing-group input[type='checkbox'] + label:hover,
+        .listing-group input[type='checkbox']:checked + label {
+            background-color: #4ea0da;
+        }
+
+        .listing-group input[type='checkbox']:checked + label:before {
+            content: '✔';
+            margin-right: 5px;
+        }
+        """
+    ).strip()
+
+    controls_markup = "".join(
+        [
+            "<input type=\"checkbox\" id=\"scrollZoom\" checked=\"checked\" />",
+            "<label for=\"scrollZoom\">Scroll zoom</label>",
+            "<input type=\"checkbox\" id=\"boxZoom\" checked=\"checked\" />",
+            "<label for=\"boxZoom\">Box zoom</label>",
+            "<input type=\"checkbox\" id=\"dragRotate\" checked=\"checked\" />",
+            "<label for=\"dragRotate\">Drag rotate</label>",
+            "<input type=\"checkbox\" id=\"dragPan\" checked=\"checked\" />",
+            "<label for=\"dragPan\">Drag pan</label>",
+            "<input type=\"checkbox\" id=\"keyboard\" checked=\"checked\" />",
+            "<label for=\"keyboard\">Keyboard</label>",
+            "<input type=\"checkbox\" id=\"doubleClickZoom\" checked=\"checked\" />",
+            "<label for=\"doubleClickZoom\">Double click zoom</label>",
+            "<input type=\"checkbox\" id=\"touchZoomRotate\" checked=\"checked\" />",
+            "<label for=\"touchZoomRotate\">Touch zoom rotate</label>",
+        ]
+    )
+
+    toggle_js = textwrap.dedent(
+        f"""
+        (function() {{
+            var container = document.createElement('nav');
+            container.id = 'listing-group';
+            container.className = 'listing-group';
+            container.innerHTML = {controls_markup!r};
+            document.body.appendChild(container);
+
+            container.addEventListener('change', function(e) {{
+                var handler = e.target && e.target.id;
+                if (!handler || typeof map[handler] === 'undefined') {{ return; }}
+                if (e.target.checked) {{
+                    map[handler].enable();
+                }} else {{
+                    map[handler].disable();
+                }}
+            }});
+        }})();
+        """
+    ).strip()
+
+    map_instance.extra_js = toggle_js
+
+    html = map_instance.render()
+    assert "listing-group" in html
+    assert "map[handler].enable()" in html
+    assert "map[handler].disable()" in html


### PR DESCRIPTION
## Summary
- add pytest parity suites for draggable points, hover states, pointer readouts, and distance measurements
- cover game-like keyboard navigation, restricted bounds, multi-map sync, and interaction toggles with new tests
- mark the corresponding MapLibre example entries as complete in status.json

## Testing
- pytest tests/test_examples -k "draggable_point or hover_effect or mouse_pointer or measure_distances or game_like_controls or restrict_map_panning or sync_movement or toggle_interactions"

------
https://chatgpt.com/codex/tasks/task_b_68d72e0aa3ec832fad85082f23be58dd