### PR TITLE
Add example parity tests for time slider and drawing demos

### DIFF
--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -383,8 +383,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-time-slider/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/create-a-time-slider.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_create_a_time_slider.py"
     },
     "create-and-style-clusters": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-and-style-clusters/",
@@ -537,8 +537,8 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-a-circle/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/draw-a-circle.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_draw_a_circle.py"
     },
     "draw-geojson-points": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-geojson-points/",
@@ -551,15 +551,15 @@
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-geometries-with-terra-draw/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/draw-geometries-with-terra-draw.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_draw_geometries_with_terra_draw.py"
     },
     "draw-polygon-with-mapbox-gl-draw": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-polygon-with-mapbox-gl-draw/",
         "source_status": true,
         "file_path": "misc/maplibre_examples/pages/draw-polygon-with-mapbox-gl-draw.html",
-        "task_status": false,
-        "script": null
+        "task_status": true,
+        "script": "tests/test_examples/test_draw_polygon_with_mapbox_gl_draw.py"
     },
     "extrude-polygons-for-3d-indoor-mapping": {
         "url": "https://maplibre.org/maplibre-gl-js/docs/examples/extrude-polygons-for-3d-indoor-mapping/",

--- a/tests/test_examples/test_create_a_time_slider.py
+++ b/tests/test_examples/test_create_a_time_slider.py
@@ -1,0 +1,203 @@
+"""Test suite for the create-a-time-slider example."""
+
+from __future__ import annotations
+
+from maplibreum import Map
+
+
+# Sample of the earthquake dataset with month property applied in the
+# original gallery example. The features below keep the structure but
+# drastically reduce the payload so the regression test remains light.
+_EARTHQUAKE_DATA = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [142.369, 38.322]},
+            "properties": {"mag": 7.0, "time": 1425640986000, "month": 2},
+        },
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [94.195, 26.692]},
+            "properties": {"mag": 6.5, "time": 1429712490000, "month": 3},
+        },
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [-71.674, -31.573]},
+            "properties": {"mag": 6.9, "time": 1438211046000, "month": 6},
+        },
+    ],
+}
+
+
+_CIRCLE_LAYER = {
+    "id": "earthquake-circles",
+    "type": "circle",
+    "source": "earthquakes",
+    "paint": {
+        "circle-color": [
+            "interpolate",
+            ["linear"],
+            ["get", "mag"],
+            6,
+            "#FCA107",
+            8,
+            "#7F3121",
+        ],
+        "circle-opacity": 0.75,
+        "circle-radius": [
+            "interpolate",
+            ["linear"],
+            ["get", "mag"],
+            6,
+            20,
+            8,
+            40,
+        ],
+    },
+}
+
+
+_LABEL_LAYER = {
+    "id": "earthquake-labels",
+    "type": "symbol",
+    "source": "earthquakes",
+    "layout": {
+        "text-field": ["concat", ["to-string", ["get", "mag"]], "m"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+    },
+    "paint": {"text-color": "rgba(0,0,0,0.5)"},
+}
+
+
+_SLIDER_CSS = """
+.time-slider-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 25%;
+    padding: 10px;
+    font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    z-index: 1000;
+}
+.time-slider-overlay .panel {
+    background: #fff;
+    border-radius: 3px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+    margin-bottom: 10px;
+    padding: 10px;
+}
+.time-slider-overlay .legend-bar {
+    height: 10px;
+    width: 100%;
+    background: linear-gradient(to right, #fca107, #7f3121);
+}
+.time-slider-overlay input[type="range"] {
+    width: 100%;
+    cursor: ew-resize;
+}
+"""
+
+
+def _slider_bootstrap_js() -> str:
+    months = [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ]
+
+    month_list = ", ".join(f"'{month}'" for month in months)
+
+    return f"""
+const container = document.querySelector('.time-slider-overlay');
+if (!container) {{
+  const overlay = document.createElement('div');
+  overlay.className = 'time-slider-overlay';
+  overlay.innerHTML = `
+    <div class="panel">
+      <h2>Significant earthquakes in 2015</h2>
+      <label id="time-slider-month" for="time-slider">January</label>
+      <input id="time-slider" type="range" min="0" max="11" step="1" value="0" />
+    </div>
+    <div class="panel">
+      <div class="legend">
+        <div class="legend-bar"></div>
+        <div>Magnitude (m)</div>
+      </div>
+    </div>`;
+  document.body.appendChild(overlay);
+}}
+const slider = document.getElementById('time-slider');
+const label = document.getElementById('time-slider-month');
+const months = [{month_list}];
+function applyMonth(month) {{
+  var filter = ['==', ['get', 'month'], month];
+  map.setFilter('earthquake-circles', filter);
+  map.setFilter('earthquake-labels', filter);
+  if (label) {{
+    label.textContent = months[month];
+  }}
+}}
+if (slider) {{
+  slider.addEventListener('input', function(evt) {{
+    applyMonth(parseInt(evt.target.value, 10));
+  }});
+  applyMonth(parseInt(slider.value || '0', 10));
+}}
+"""
+
+
+def test_create_a_time_slider() -> None:
+    """Reproduce the create-a-time-slider gallery example."""
+
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[31.4606, 20.7927],
+        zoom=0.5,
+        custom_css=_SLIDER_CSS,
+    )
+
+    m.add_source("earthquakes", _EARTHQUAKE_DATA)
+    m.add_layer(_CIRCLE_LAYER)
+    m.add_layer(_LABEL_LAYER)
+    m.add_on_load_js(_slider_bootstrap_js())
+
+    # Validate the stored configuration prior to rendering.
+    source_names = [entry["name"] for entry in m.sources]
+    assert "earthquakes" in source_names
+
+    source_def = next(entry for entry in m.sources if entry["name"] == "earthquakes")
+    assert source_def["definition"]["type"] == "FeatureCollection"
+    assert len(source_def["definition"]["features"]) == 3
+    assert source_def["definition"]["features"][0]["properties"]["month"] == 2
+
+    layer_ids = [layer["id"] for layer in m.layers]
+    assert layer_ids == ["earthquake-circles", "earthquake-labels"]
+
+    circle_def = m.layers[0]["definition"]
+    assert circle_def["paint"]["circle-opacity"] == 0.75
+    assert circle_def["paint"]["circle-radius"][0] == "interpolate"
+
+    label_def = m.layers[1]["definition"]
+    assert label_def["layout"]["text-font"] == ["Noto Sans Regular"]
+    assert label_def["paint"]["text-color"] == "rgba(0,0,0,0.5)"
+
+    assert any("map.setFilter('earthquake-circles'" in cb for cb in m._on_load_callbacks)
+
+    html = m.render()
+
+    assert "time-slider-overlay" in html
+    assert "Significant earthquakes in 2015" in html
+    assert "Magnitude (m)" in html
+    assert "applyMonth" in html
+    assert "slider.addEventListener('input'" in html

--- a/tests/test_examples/test_draw_a_circle.py
+++ b/tests/test_examples/test_draw_a_circle.py
@@ -1,0 +1,114 @@
+"""Regression test for the draw-a-circle gallery example."""
+
+from __future__ import annotations
+
+import math
+
+from maplibreum import Map
+
+
+_RADIUS_CENTER = [2.3454, 48.8452]
+
+
+def _geodesic_circle(center: list[float], radius_km: float, steps: int) -> dict:
+    """Generate a GeoJSON polygon approximating a circle on Earth."""
+
+    if steps < 3:
+        raise ValueError("steps must be at least 3 to form a polygon")
+
+    lng_rad = math.radians(center[0])
+    lat_rad = math.radians(center[1])
+    angular_distance = radius_km / 6371.0
+    coordinates: list[list[float]] = []
+
+    for index in range(steps):
+        bearing = 2.0 * math.pi * index / steps
+        lat_point = math.asin(
+            math.sin(lat_rad) * math.cos(angular_distance)
+            + math.cos(lat_rad) * math.sin(angular_distance) * math.cos(bearing)
+        )
+        lng_point = lng_rad + math.atan2(
+            math.sin(bearing) * math.sin(angular_distance) * math.cos(lat_rad),
+            math.cos(angular_distance) - math.sin(lat_rad) * math.sin(lat_point),
+        )
+        coordinates.append([math.degrees(lng_point), math.degrees(lat_point)])
+
+    coordinates.append(coordinates[0])
+
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Polygon", "coordinates": [coordinates]},
+                "properties": {},
+            }
+        ],
+    }
+
+
+def test_draw_a_circle() -> None:
+    """Reproduce drawing a circle using a GeoJSON source."""
+
+    map_style = {
+        "version": 8,
+        "sources": {
+            "osm": {
+                "type": "raster",
+                "tiles": ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+                "tileSize": 256,
+                "attribution": "&copy; OpenStreetMap Contributors",
+                "maxzoom": 19,
+            }
+        },
+        "layers": [{"id": "osm", "type": "raster", "source": "osm"}],
+    }
+
+    m = Map(
+        map_style=map_style,
+        center=_RADIUS_CENTER,
+        zoom=13,
+        map_options={"maxZoom": 18, "maxPitch": 85},
+    )
+
+    circle_data = _geodesic_circle(_RADIUS_CENTER, radius_km=1, steps=64)
+    m.add_source("location-radius", circle_data)
+
+    m.add_layer(
+        {
+            "id": "location-radius",
+            "type": "fill",
+            "source": "location-radius",
+            "paint": {"fill-color": "#8CCFFF", "fill-opacity": 0.5},
+        }
+    )
+    m.add_layer(
+        {
+            "id": "location-radius-outline",
+            "type": "line",
+            "source": "location-radius",
+            "paint": {"line-color": "#0094ff", "line-width": 3},
+        }
+    )
+
+    assert m.map_style == map_style
+    assert m.additional_map_options == {"maxZoom": 18, "maxPitch": 85}
+
+    assert m.sources[0]["name"] == "location-radius"
+    polygon = m.sources[0]["definition"]["features"][0]["geometry"]
+    assert polygon["type"] == "Polygon"
+    assert len(polygon["coordinates"][0]) == 65
+
+    fill_layer = next(layer for layer in m.layers if layer["id"] == "location-radius")
+    assert fill_layer["definition"]["paint"]["fill-color"] == "#8CCFFF"
+    assert fill_layer["definition"]["paint"]["fill-opacity"] == 0.5
+
+    outline_layer = next(
+        layer for layer in m.layers if layer["id"] == "location-radius-outline"
+    )
+    assert outline_layer["definition"]["paint"]["line-width"] == 3
+
+    html = m.render()
+    assert "tile.openstreetmap.org" in html
+    assert "location-radius" in html
+    assert "fill-opacity" in html

--- a/tests/test_examples/test_draw_geometries_with_terra_draw.py
+++ b/tests/test_examples/test_draw_geometries_with_terra_draw.py
@@ -1,0 +1,85 @@
+"""Regression test for draw-geometries-with-terra-draw example."""
+
+from __future__ import annotations
+
+from maplibreum import Map
+
+
+_TERRA_DRAW_SCRIPT = (
+    "https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@1.0.1/dist/"
+    "maplibre-gl-terradraw.umd.js"
+)
+_TERRA_DRAW_CSS = (
+    "@import url('https://cdn.jsdelivr.net/npm/@watergis/maplibre-gl-terradraw@1.0.1/dist/"
+    "maplibre-gl-terradraw.css');"
+)
+_TERRA_MODES = [
+    "point",
+    "linestring",
+    "polygon",
+    "rectangle",
+    "circle",
+    "freehand",
+    "angled-rectangle",
+    "sensor",
+    "sector",
+    "select",
+    "delete-selection",
+    "delete",
+    "download",
+]
+
+
+def _terra_bootstrap_js() -> str:
+    modes_js = ", ".join(f"'{mode}'" for mode in _TERRA_MODES)
+    return f"""
+var terraNamespace = window.MaplibreTerradrawControl || (window.MaplibreTerradrawControl = {{}});
+if (typeof terraNamespace.MaplibreTerradrawControl !== 'function') {{
+  terraNamespace.MaplibreTerradrawControl = function(options) {{
+    this.options = options || {{}};
+    this.name = 'mock-terradraw-control';
+    this.position = null;
+  }};
+  terraNamespace.MaplibreTerradrawControl.prototype.onAdd = function(mapInstance) {{
+    this._map = mapInstance;
+    var container = document.createElement('div');
+    container.className = 'mock-terradraw-control';
+    container.textContent = 'TerraDraw';
+    return container;
+  }};
+  terraNamespace.MaplibreTerradrawControl.prototype.onRemove = function() {{
+    this._map = null;
+  }};
+}}
+var terraControl = new terraNamespace.MaplibreTerradrawControl({{
+  modes: [{modes_js}],
+  open: true
+}});
+if (typeof map.addControl === 'function') {{
+  map.addControl(terraControl, 'top-left');
+}}
+"""
+
+
+def test_draw_geometries_with_terra_draw() -> None:
+    """Ensure Terra Draw integration mirrors the gallery example."""
+
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-91.874, 42.76],
+        zoom=12,
+        custom_css=_TERRA_DRAW_CSS,
+    )
+    m.add_external_script(_TERRA_DRAW_SCRIPT)
+    m.add_on_load_js(_terra_bootstrap_js())
+
+    assert m.external_scripts[0]["src"] == _TERRA_DRAW_SCRIPT
+    assert _TERRA_DRAW_CSS in m.custom_css
+    assert len(m._on_load_callbacks) == 1
+    assert "MaplibreTerradrawControl" in m._on_load_callbacks[0]
+    assert "modes: ['point', 'linestring'" in m._on_load_callbacks[0]
+
+    html = m.render()
+    assert _TERRA_DRAW_SCRIPT in html
+    assert "mock-terradraw-control" in html
+    assert "modes: ['point', 'linestring', 'polygon'" in html

--- a/tests/test_examples/test_draw_polygon_with_mapbox_gl_draw.py
+++ b/tests/test_examples/test_draw_polygon_with_mapbox_gl_draw.py
@@ -1,0 +1,295 @@
+"""Regression test for draw-polygon-with-mapbox-gl-draw example."""
+
+from __future__ import annotations
+
+from maplibreum import Map
+
+
+_CALCULATION_CSS = """
+.calculation-box {
+    height: 75px;
+    width: 150px;
+    position: absolute;
+    bottom: 40px;
+    left: 10px;
+    background-color: rgba(255, 255, 255, 0.9);
+    padding: 15px;
+    text-align: center;
+    z-index: 1000;
+}
+.calculation-box p {
+    font-family: 'Open Sans';
+    margin: 0;
+    font-size: 13px;
+}
+"""
+
+_DRAW_STYLES = [
+    {
+        "id": "gl-draw-polygon-fill-inactive",
+        "type": "fill",
+        "filter": [
+            "all",
+            ["==", "active", "false"],
+            ["==", "$type", "Polygon"],
+            ["!=", "mode", "static"],
+        ],
+        "paint": {
+            "fill-color": "#3bb2d0",
+            "fill-outline-color": "#3bb2d0",
+            "fill-opacity": 0.1,
+        },
+    },
+    {
+        "id": "gl-draw-polygon-fill-active",
+        "type": "fill",
+        "filter": ["all", ["==", "active", "true"], ["==", "$type", "Polygon"]],
+        "paint": {
+            "fill-color": "#fbb03b",
+            "fill-outline-color": "#fbb03b",
+            "fill-opacity": 0.1,
+        },
+    },
+    {
+        "id": "gl-draw-polygon-midpoint",
+        "type": "circle",
+        "filter": [
+            "all",
+            ["==", "$type", "Point"],
+            ["==", "meta", "midpoint"],
+        ],
+        "paint": {"circle-radius": 3, "circle-color": "#fbb03b"},
+    },
+    {
+        "id": "gl-draw-polygon-stroke-inactive",
+        "type": "line",
+        "filter": [
+            "all",
+            ["==", "active", "false"],
+            ["==", "$type", "Polygon"],
+            ["!=", "mode", "static"],
+        ],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {"line-color": "#3bb2d0", "line-width": 2},
+    },
+    {
+        "id": "gl-draw-polygon-stroke-active",
+        "type": "line",
+        "filter": ["all", ["==", "active", "true"], ["==", "$type", "Polygon"]],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {
+            "line-color": "#fbb03b",
+            "line-dasharray": [0.2, 2],
+            "line-width": 2,
+        },
+    },
+    {
+        "id": "gl-draw-line-inactive",
+        "type": "line",
+        "filter": [
+            "all",
+            ["==", "active", "false"],
+            ["==", "$type", "LineString"],
+            ["!=", "mode", "static"],
+        ],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {"line-color": "#3bb2d0", "line-width": 2},
+    },
+    {
+        "id": "gl-draw-line-active",
+        "type": "line",
+        "filter": [
+            "all",
+            ["==", "$type", "LineString"],
+            ["==", "active", "true"],
+        ],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {
+            "line-color": "#fbb03b",
+            "line-dasharray": [0.2, 2],
+            "line-width": 2,
+        },
+    },
+    {
+        "id": "gl-draw-polygon-and-line-vertex-stroke-inactive",
+        "type": "circle",
+        "filter": [
+            "all",
+            ["==", "meta", "vertex"],
+            ["==", "$type", "Point"],
+            ["!=", "mode", "static"],
+        ],
+        "paint": {"circle-radius": 5, "circle-color": "#fff"},
+    },
+    {
+        "id": "gl-draw-polygon-and-line-vertex-inactive",
+        "type": "circle",
+        "filter": [
+            "all",
+            ["==", "meta", "vertex"],
+            ["==", "$type", "Point"],
+            ["!=", "mode", "static"],
+        ],
+        "paint": {"circle-radius": 3, "circle-color": "#fbb03b"},
+    },
+    {
+        "id": "gl-draw-point-point-stroke-inactive",
+        "type": "circle",
+        "filter": [
+            "all",
+            ["==", "active", "false"],
+            ["==", "$type", "Point"],
+            ["==", "meta", "feature"],
+            ["!=", "mode", "static"],
+        ],
+        "paint": {
+            "circle-radius": 5,
+            "circle-opacity": 1,
+            "circle-color": "#fff",
+        },
+    },
+    {
+        "id": "gl-draw-point-inactive",
+        "type": "circle",
+        "filter": [
+            "all",
+            ["==", "active", "false"],
+            ["==", "$type", "Point"],
+            ["==", "meta", "feature"],
+            ["!=", "mode", "static"],
+        ],
+        "paint": {"circle-radius": 3, "circle-color": "#3bb2d0"},
+    },
+    {
+        "id": "gl-draw-point-stroke-active",
+        "type": "circle",
+        "filter": [
+            "all",
+            ["==", "$type", "Point"],
+            ["==", "active", "true"],
+            ["!=", "meta", "midpoint"],
+        ],
+        "paint": {"circle-radius": 7, "circle-color": "#fff"},
+    },
+    {
+        "id": "gl-draw-point-active",
+        "type": "circle",
+        "filter": [
+            "all",
+            ["==", "$type", "Point"],
+            ["!=", "meta", "midpoint"],
+            ["==", "active", "true"],
+        ],
+        "paint": {"circle-radius": 5, "circle-color": "#fbb03b"},
+    },
+    {
+        "id": "gl-draw-polygon-fill-static",
+        "type": "fill",
+        "filter": ["all", ["==", "mode", "static"], ["==", "$type", "Polygon"]],
+        "paint": {
+            "fill-color": "#404040",
+            "fill-outline-color": "#404040",
+            "fill-opacity": 0.1,
+        },
+    },
+    {
+        "id": "gl-draw-polygon-stroke-static",
+        "type": "line",
+        "filter": ["all", ["==", "mode", "static"], ["==", "$type", "Polygon"]],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {"line-color": "#404040", "line-width": 2},
+    },
+    {
+        "id": "gl-draw-line-static",
+        "type": "line",
+        "filter": ["all", ["==", "mode", "static"], ["==", "$type", "LineString"]],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {"line-color": "#404040", "line-width": 2},
+    },
+    {
+        "id": "gl-draw-point-static",
+        "type": "circle",
+        "filter": ["all", ["==", "mode", "static"], ["==", "$type", "Point"]],
+        "paint": {"circle-radius": 5, "circle-color": "#404040"},
+    },
+]
+
+
+def _draw_bootstrap_js() -> str:
+    return """
+MapboxDraw.constants.classes.CANVAS = 'maplibregl-canvas';
+MapboxDraw.constants.classes.CONTROL_BASE = 'maplibregl-ctrl';
+MapboxDraw.constants.classes.CONTROL_PREFIX = 'maplibregl-ctrl-';
+MapboxDraw.constants.classes.CONTROL_GROUP = 'maplibregl-ctrl-group';
+MapboxDraw.constants.classes.ATTRIBUTION = 'maplibregl-ctrl-attrib';
+if (typeof window.turf !== 'object') {
+  window.turf = {
+    area: function(collection) {
+      if (!collection || !collection.features) {
+        return 0;
+      }
+      return collection.features.length * 123.45;
+    }
+  };
+}
+var box = document.querySelector('.calculation-box');
+if (!box) {
+  box = document.createElement('div');
+  box.className = 'calculation-box';
+  box.innerHTML = '<p>Draw a polygon using the draw tools.</p><div id="calculated-area"></div>';
+  document.body.appendChild(box);
+}
+var output = document.getElementById('calculated-area');
+function updateArea(e) {
+  var data = draw.getAll();
+  if (data.features.length > 0) {
+    var area = window.turf.area(data);
+    var rounded = Math.round(area * 100) / 100;
+    if (output) {
+      output.innerHTML = '<p><strong>' + rounded + '</strong></p><p>square meters</p>';
+    }
+  } else {
+    if (output) {
+      output.innerHTML = '';
+    }
+    if (e.type !== 'draw.delete') {
+      window.alert('Use the draw tools to draw a polygon!');
+    }
+  }
+}
+map.on('draw.create', updateArea);
+map.on('draw.update', updateArea);
+map.on('draw.delete', updateArea);
+"""
+
+
+def test_draw_polygon_with_mapbox_gl_draw() -> None:
+    """Ensure Mapbox GL Draw configuration matches the gallery example."""
+
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-91.874, 42.76],
+        zoom=12,
+        custom_css=_CALCULATION_CSS,
+    )
+    m.add_draw_control(
+        {
+            "displayControlsDefault": False,
+            "controls": {"polygon": True, "trash": True},
+            "styles": _DRAW_STYLES,
+        }
+    )
+    m.add_on_load_js(_draw_bootstrap_js())
+
+    assert m.draw_control is True
+    assert m.draw_control_options["displayControlsDefault"] is False
+    assert m.draw_control_options["controls"] == {"polygon": True, "trash": True}
+    assert m.draw_control_options["styles"] == _DRAW_STYLES
+
+    assert any("MapboxDraw.constants.classes.CANVAS" in cb for cb in m._on_load_callbacks)
+    assert any("map.on('draw.create', updateArea" in cb for cb in m._on_load_callbacks)
+
+    html = m.render()
+    assert "Draw a polygon using the draw tools." in html
+    assert "mapbox-gl-draw.js" in html
+    assert "window.alert('Use the draw tools to draw a polygon!'" in html


### PR DESCRIPTION
## Summary
- add a regression test for the create-a-time-slider gallery example including the slider UI bootstrapping code
- cover the draw-a-circle, Terra Draw, and Mapbox GL Draw examples with focused pytest modules and mock integrations
- mark the corresponding examples as implemented in misc/maplibre_examples/status.json

## Testing
- pytest tests/test_examples -k "time_slider or draw_a_circle or terra_draw or mapbox_gl_draw"

------
https://chatgpt.com/codex/tasks/task_b_68d744caeaa8832fa55ce09a2187fc5c