### PR TITLE
Add tests for styling and filtering gallery examples

### DIFF
--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -1,865 +1,865 @@
 {
-    "3d-terrain": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/3d-terrain/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/3d-terrain.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_3d_terrain.py"
-    },
-    "add-a-3d-model-to-globe-using-threejs": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-to-globe-using-threejs/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-3d-model-to-globe-using-threejs.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_3d_model_to_globe_using_threejs.py"
-    },
-    "add-a-3d-model-using-threejs": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-using-threejs/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-3d-model-using-threejs.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_3d_model_using_threejs.py"
-    },
-    "add-a-3d-model-with-babylonjs": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-with-babylonjs/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-3d-model-with-babylonjs.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_3d_model_with_babylonjs.py"
-    },
-    "add-a-3d-model-with-shadow-using-threejs": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-with-shadow-using-threejs/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-3d-model-with-shadow-using-threejs.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_3d_model_with_shadow_using_threejs.py"
-    },
-    "add-a-canvas-source": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-canvas-source/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-canvas-source.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_canvas_source.py"
-    },
-    "add-a-cog-raster-source": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-cog-raster-source/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-cog-raster-source.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_cog_raster_source.py"
-    },
-    "add-a-color-relief-layer": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-color-relief-layer/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-color-relief-layer.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_color_relief_layer.py"
-    },
-    "add-a-custom-layer-with-tiles-to-a-globe": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-custom-layer-with-tiles-to-a-globe/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-custom-layer-with-tiles-to-a-globe.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_custom_layer_with_tiles_to_a_globe.py"
-    },
-    "add-a-custom-style-layer": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-custom-style-layer/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-custom-style-layer.html",
-        "task_status": true,
-        "script": null,
-        "notes": "Skipped: Requires custom WebGL layer, which is not yet supported."
-    },
-    "add-a-default-marker": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-default-marker/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-default-marker.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_default_marker.py"
-    },
-    "add-a-generated-icon-to-the-map": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-generated-icon-to-the-map/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-generated-icon-to-the-map.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_generated_icon_to_the_map.py"
-    },
-    "add-a-geojson-line": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-geojson-line/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-geojson-line.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_geojson_line.py"
-    },
-    "add-a-geojson-polygon": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-geojson-polygon/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-geojson-polygon.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_geojson_polygon.py"
-    },
-    "add-a-hillshade-layer": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-hillshade-layer/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-hillshade-layer.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_hillshade_layer.py"
-    },
-    "add-a-multidirectional-hillshade-layer": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-multidirectional-hillshade-layer/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-multidirectional-hillshade-layer.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_multidirectional_hillshade_layer.py"
-    },
-    "add-a-new-layer-below-labels": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-new-layer-below-labels/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-new-layer-below-labels.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_new_layer_below_labels.py"
-    },
-    "add-a-pattern-to-a-polygon": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-pattern-to-a-polygon/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-pattern-to-a-polygon.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_pattern_to_a_polygon.py"
-    },
-    "add-a-raster-tile-source": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-raster-tile-source/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-raster-tile-source.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_raster_tile_source.py"
-    },
-    "add-a-simple-custom-layer-on-a-globe": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-simple-custom-layer-on-a-globe/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-simple-custom-layer-on-a-globe.html",
-        "task_status": true,
-        "script": null,
-        "notes": "Skipped: Requires custom WebGL layer, which is not yet supported."
-    },
-    "add-a-stretchable-image-to-the-map": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-stretchable-image-to-the-map/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-stretchable-image-to-the-map.html",
-        "task_status": true,
-        "script": null
-    },
-    "add-a-vector-tile-source": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-vector-tile-source/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-vector-tile-source.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_vector_tile_source.py"
-    },
-    "add-a-video": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-video/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-video.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_video.py"
-    },
-    "add-a-wms-source": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-wms-source/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-a-wms-source.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_a_wms_source.py"
-    },
-    "add-an-animated-icon-to-the-map": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-an-animated-icon-to-the-map/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-an-animated-icon-to-the-map.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_an_animated_icon_to_the_map.py"
-    },
-    "add-an-icon-to-the-map": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-an-icon-to-the-map/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-an-icon-to-the-map.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_an_icon_to_the_map.py"
-    },
-    "add-contour-lines": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-contour-lines/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-contour-lines.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_contour_lines.py"
-    },
-    "add-custom-icons-with-markers": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-custom-icons-with-markers/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-custom-icons-with-markers.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_custom_icons_with_markers.py"
-    },
-    "add-live-realtime-data": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-live-realtime-data/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-live-realtime-data.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_live_realtime_data.py"
-    },
-    "add-multiple-geometries-from-one-geojson-source": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-multiple-geometries-from-one-geojson-source/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-multiple-geometries-from-one-geojson-source.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_multiple_geometries_from_one_geojson_source.py"
-    },
-    "add-support-for-right-to-left-scripts": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-support-for-right-to-left-scripts/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/add-support-for-right-to-left-scripts.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_add_support_for_right_to_left_scripts.py"
-    },
-    "adding-3d-models-using-threejs-on-terrain": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/adding-3d-models-using-threejs-on-terrain/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/adding-3d-models-using-threejs-on-terrain.html",
-        "task_status": false,
-        "script": null
-    },
-    "animate-a-line": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-line/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/animate-a-line.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_animate_a_line.py"
-    },
-    "animate-a-marker": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-marker/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/animate-a-marker.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_animate_a_marker.py"
-    },
-    "animate-a-point": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/animate-a-point.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_animate_a_point.py"
-    },
-    "animate-a-point-along-a-route": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point-along-a-route/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/animate-a-point-along-a-route.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_animate_a_point_along_a_route.py"
-    },
-    "animate-a-series-of-images": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-series-of-images/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/animate-a-series-of-images.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_animate_a_series_of_images.py"
-    },
-    "animate-map-camera-around-a-point": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-map-camera-around-a-point/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/animate-map-camera-around-a-point.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_animate_map_camera_around_a_point.py"
-    },
-    "animate-symbol-to-follow-the-mouse": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-symbol-to-follow-the-mouse/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/animate-symbol-to-follow-the-mouse.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_animate_symbol_to_follow_the_mouse.py"
-    },
-    "attach-a-popup-to-a-marker-instance": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/attach-a-popup-to-a-marker-instance/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/attach-a-popup-to-a-marker-instance.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_attach_a_popup_to_a_marker_instance.py"
-    },
-    "center-the-map-on-a-clicked-symbol": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/center-the-map-on-a-clicked-symbol/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/center-the-map-on-a-clicked-symbol.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_center_the_map_on_a_clicked_symbol.py"
-    },
-    "change-a-layers-color-with-buttons": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-a-layers-color-with-buttons/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/change-a-layers-color-with-buttons.html",
-        "task_status": false,
-        "script": null
-    },
-    "change-a-maps-language": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-a-maps-language/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/change-a-maps-language.html",
-        "task_status": false,
-        "script": null
-    },
-    "change-building-color-based-on-zoom-level": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-building-color-based-on-zoom-level/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/change-building-color-based-on-zoom-level.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_change_building_color_based_on_zoom_level.py"
-    },
-    "change-the-case-of-labels": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-the-case-of-labels/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/change-the-case-of-labels.html",
-        "task_status": false,
-        "script": null
-    },
-    "change-the-default-position-for-attribution": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-the-default-position-for-attribution/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/change-the-default-position-for-attribution.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_change_the_default_position_for_attribution.py"
-    },
-    "check-if-webgl-is-supported": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/check-if-webgl-is-supported/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/check-if-webgl-is-supported.html",
-        "task_status": false,
-        "script": null
-    },
-    "cooperative-gestures": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/cooperative-gestures/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/cooperative-gestures.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_cooperative_gestures.py"
-    },
-    "create-a-draggable-marker": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-draggable-marker/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/create-a-draggable-marker.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_create_a_draggable_marker.py"
-    },
-    "create-a-draggable-point": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-draggable-point/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/create-a-draggable-point.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_create_a_draggable_point.py"
-    },
-    "create-a-gradient-line-using-an-expression": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-gradient-line-using-an-expression/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/create-a-gradient-line-using-an-expression.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_create_a_gradient_line_using_an_expression.py"
-    },
-    "create-a-heatmap-layer": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-heatmap-layer/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/create-a-heatmap-layer.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_create_a_heatmap_layer.py"
-    },
-    "create-a-heatmap-layer-on-a-globe-with-terrain-elevation": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-heatmap-layer-on-a-globe-with-terrain-elevation/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/create-a-heatmap-layer-on-a-globe-with-terrain-elevation.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_create_a_heatmap_layer_on_a_globe_with_terrain_elevation.py"
-    },
-    "create-a-hover-effect": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-hover-effect/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/create-a-hover-effect.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_create_a_hover_effect.py"
-    },
-    "create-a-time-slider": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-time-slider/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/create-a-time-slider.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_create_a_time_slider.py"
-    },
-    "create-and-style-clusters": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-and-style-clusters/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/create-and-style-clusters.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_create_and_style_clusters.py"
-    },
-    "create-deckgl-layer-using-rest-api": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-deckgl-layer-using-rest-api/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/create-deckgl-layer-using-rest-api.html",
-        "task_status": false,
-        "script": null
-    },
-    "customize-camera-animations": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/customize-camera-animations/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/customize-camera-animations.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_customize_camera_animations.py"
-    },
-    "disable-map-rotation": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/disable-map-rotation/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/disable-map-rotation.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_disable_map_rotation.py"
-    },
-    "disable-scroll-zoom": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/disable-scroll-zoom/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/disable-scroll-zoom.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_disable_scroll_zoom.py"
-    },
-    "display-a-globe-with-a-fill-extrusion-layer": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-a-fill-extrusion-layer/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-a-globe-with-a-fill-extrusion-layer.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_a_globe_with_a_fill_extrusion_layer.py"
-    },
-    "display-a-globe-with-a-vector-map": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-a-vector-map/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-a-globe-with-a-vector-map.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_a_globe_with_a_vector_map.py"
-    },
-    "display-a-globe-with-an-atmosphere": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-an-atmosphere/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-a-globe-with-an-atmosphere.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_a_globe_with_an_atmosphere.py"
-    },
-    "display-a-hybrid-satellite-map-with-terrain-elevation": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-hybrid-satellite-map-with-terrain-elevation/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-a-hybrid-satellite-map-with-terrain-elevation.html",
-        "task_status": false,
-        "script": null
-    },
-    "display-a-map": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-map/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-a-map.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_a_map.py"
-    },
-    "display-a-non-interactive-map": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-non-interactive-map/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-a-non-interactive-map.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_a_non_interactive_map.py"
-    },
-    "display-a-popup": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-a-popup.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_a_popup.py"
-    },
-    "display-a-popup-on-click": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup-on-click/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-a-popup-on-click.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_a_popup_on_click.py"
-    },
-    "display-a-popup-on-hover": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup-on-hover/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-a-popup-on-hover.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_a_popup_on_hover.py"
-    },
-    "display-a-remote-svg-symbol": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-remote-svg-symbol/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-a-remote-svg-symbol.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_a_remote_svg_symbol.py"
-    },
-    "display-a-satellite-map": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-satellite-map/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-a-satellite-map.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_a_satellite_map.py"
-    },
-    "display-and-style-rich-text-labels": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-and-style-rich-text-labels/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-and-style-rich-text-labels.html",
-        "task_status": false,
-        "script": null
-    },
-    "display-buildings-in-3d": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-buildings-in-3d/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-buildings-in-3d.html",
-        "task_status": false,
-        "script": null
-    },
-    "display-html-clusters-with-custom-properties": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-html-clusters-with-custom-properties/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-html-clusters-with-custom-properties.html",
-        "task_status": false,
-        "script": null
-    },
-    "display-line-that-crosses-180th-meridian": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-line-that-crosses-180th-meridian/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-line-that-crosses-180th-meridian.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_line_that_crosses_180th_meridian.py"
-    },
-    "display-map-navigation-controls": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-map-navigation-controls/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/display-map-navigation-controls.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_display_map_navigation_controls.py"
-    },
-    "draw-a-circle": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-a-circle/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/draw-a-circle.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_draw_a_circle.py"
-    },
-    "draw-geojson-points": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-geojson-points/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/draw-geojson-points.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_draw_geojson_points.py"
-    },
-    "draw-geometries-with-terra-draw": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-geometries-with-terra-draw/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/draw-geometries-with-terra-draw.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_draw_geometries_with_terra_draw.py"
-    },
-    "draw-polygon-with-mapbox-gl-draw": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-polygon-with-mapbox-gl-draw/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/draw-polygon-with-mapbox-gl-draw.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_draw_polygon_with_mapbox_gl_draw.py"
-    },
-    "extrude-polygons-for-3d-indoor-mapping": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/extrude-polygons-for-3d-indoor-mapping/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/extrude-polygons-for-3d-indoor-mapping.html",
-        "task_status": false,
-        "script": null
-    },
-    "filter-layer-symbols-using-global-state": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-layer-symbols-using-global-state/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/filter-layer-symbols-using-global-state.html",
-        "task_status": false,
-        "script": null
-    },
-    "filter-symbols-by-text-input": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-symbols-by-text-input/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/filter-symbols-by-text-input.html",
-        "task_status": false,
-        "script": null
-    },
-    "filter-symbols-by-toggling-a-list": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-symbols-by-toggling-a-list/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/filter-symbols-by-toggling-a-list.html",
-        "task_status": false,
-        "script": null
-    },
-    "filter-within-a-layer": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-within-a-layer/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/filter-within-a-layer.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_filter_within_a_layer.py"
-    },
-    "fit-a-map-to-a-bounding-box": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fit-a-map-to-a-bounding-box/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/fit-a-map-to-a-bounding-box.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_fit_a_map_to_a_bounding_box.py"
-    },
-    "fit-to-the-bounds-of-a-linestring": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fit-to-the-bounds-of-a-linestring/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/fit-to-the-bounds-of-a-linestring.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_fit_to_the_bounds_of_a_linestring.py"
-    },
-    "fly-to-a-location": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fly-to-a-location/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/fly-to-a-location.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_fly_to_a_location.py"
-    },
-    "fly-to-a-location-based-on-scroll-position": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fly-to-a-location-based-on-scroll-position/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/fly-to-a-location-based-on-scroll-position.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_fly_to_a_location_based_on_scroll_position.py"
-    },
-    "generate-and-add-a-missing-icon-to-the-map": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/generate-and-add-a-missing-icon-to-the-map/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/generate-and-add-a-missing-icon-to-the-map.html",
-        "task_status": false,
-        "script": null
-    },
-    "geocode-with-nominatim": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/geocode-with-nominatim/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/geocode-with-nominatim.html",
-        "task_status": false,
-        "script": null
-    },
-    "get-coordinates-of-the-mouse-pointer": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/get-coordinates-of-the-mouse-pointer/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/get-coordinates-of-the-mouse-pointer.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_get_coordinates_of_the_mouse_pointer.py"
-    },
-    "get-features-under-the-mouse-pointer": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/get-features-under-the-mouse-pointer/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/get-features-under-the-mouse-pointer.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_get_features_under_the_mouse_pointer.py"
-    },
-    "hash-routing": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/hash-routing/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/hash-routing.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_hash_routing.py"
-    },
-    "jump-to-a-series-of-locations": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/jump-to-a-series-of-locations/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/jump-to-a-series-of-locations.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_jump_to_a_series_of_locations.py"
-    },
-    "level-of-detail-control": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/level-of-detail-control/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/level-of-detail-control.html",
-        "task_status": false,
-        "script": null
-    },
-    "locate-the-user": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/locate-the-user/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/locate-the-user.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_locate_the_user.py"
-    },
-    "measure-distances": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/measure-distances/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/measure-distances.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_measure_distances.py"
-    },
-    "navigate-the-map-with-game-like-controls": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/navigate-the-map-with-game-like-controls/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/navigate-the-map-with-game-like-controls.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_navigate_the_map_with_game_like_controls.py"
-    },
-    "offset-the-vanishing-point-using-padding": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/offset-the-vanishing-point-using-padding/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/offset-the-vanishing-point-using-padding.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_offset_the_vanishing_point_using_padding.py"
-    },
-    "pmtiles-source-and-protocol": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/pmtiles-source-and-protocol/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/pmtiles-source-and-protocol.html",
-        "task_status": false,
-        "script": null
-    },
-    "render-world-copies": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/render-world-copies/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/render-world-copies.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_render_world_copies.py"
-    },
-    "restrict-map-panning-to-an-area": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/restrict-map-panning-to-an-area/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/restrict-map-panning-to-an-area.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_restrict_map_panning_to_an_area.py"
-    },
-    "set-center-point-above-ground": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/set-center-point-above-ground/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/set-center-point-above-ground.html",
-        "task_status": false,
-        "script": null
-    },
-    "set-pitch-and-bearing": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/set-pitch-and-bearing/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/set-pitch-and-bearing.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_set_pitch_and_bearing.py"
-    },
-    "show-polygon-information-on-click": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/show-polygon-information-on-click/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/show-polygon-information-on-click.html",
-        "task_status": false,
-        "script": null
-    },
-    "sky-fog-terrain": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/sky-fog-terrain/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/sky-fog-terrain.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_sky_fog_terrain.py"
-    },
-    "slowly-fly-to-a-location": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/slowly-fly-to-a-location/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/slowly-fly-to-a-location.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_slowly_fly_to_a_location.py"
-    },
-    "style-lines-with-a-data-driven-property": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/style-lines-with-a-data-driven-property/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/style-lines-with-a-data-driven-property.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_style_lines_with_a_data_driven_property.py"
-    },
-    "sync-movement-of-multiple-maps": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/sync-movement-of-multiple-maps/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/sync-movement-of-multiple-maps.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_sync_movement_of_multiple_maps.py"
-    },
-    "toggle-deckgl-layer": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-deckgl-layer/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/toggle-deckgl-layer.html",
-        "task_status": false,
-        "script": null
-    },
-    "toggle-interactions": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-interactions/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/toggle-interactions.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_toggle_interactions.py"
-    },
-    "update-a-feature-in-realtime": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/update-a-feature-in-realtime/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/update-a-feature-in-realtime.html",
-        "task_status": false,
-        "script": null
-    },
-    "use-a-fallback-image": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-a-fallback-image/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/use-a-fallback-image.html",
-        "task_status": false,
-        "script": null
-    },
-    "use-addprotocol-to-transform-feature-properties": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-addprotocol-to-transform-feature-properties/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/use-addprotocol-to-transform-feature-properties.html",
-        "task_status": false,
-        "script": null
-    },
-    "use-locally-generated-ideographs": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-locally-generated-ideographs/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/use-locally-generated-ideographs.html",
-        "task_status": false,
-        "script": null
-    },
-    "variable-label-placement": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/variable-label-placement.html",
-        "task_status": false,
-        "script": null
-    },
-    "variable-label-placement-with-offset": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement-with-offset/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/variable-label-placement-with-offset.html",
-        "task_status": false,
-        "script": null
-    },
-    "view-a-fullscreen-map": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-a-fullscreen-map/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/view-a-fullscreen-map.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_view_a_fullscreen_map.py"
-    },
-    "view-local-geojson": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-local-geojson/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/view-local-geojson.html",
-        "task_status": false,
-        "script": null
-    },
-    "view-local-geojson-experimental": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-local-geojson-experimental/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/view-local-geojson-experimental.html",
-        "task_status": false,
-        "script": null
-    },
-    "visualize-population-density": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/visualize-population-density.html",
-        "task_status": true,
-        "script": "tests/test_examples/test_visualize_population_density.py"
-    },
-    "zoom-and-planet-size-relation-on-globe": {
-        "url": "https://maplibre.org/maplibre-gl-js/docs/examples/zoom-and-planet-size-relation-on-globe/",
-        "source_status": true,
-        "file_path": "misc/maplibre_examples/pages/zoom-and-planet-size-relation-on-globe.html",
-        "task_status": false,
-        "script": null
-    }
+  "3d-terrain": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/3d-terrain/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/3d-terrain.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_3d_terrain.py"
+  },
+  "add-a-3d-model-to-globe-using-threejs": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-to-globe-using-threejs/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-3d-model-to-globe-using-threejs.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_3d_model_to_globe_using_threejs.py"
+  },
+  "add-a-3d-model-using-threejs": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-using-threejs/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-3d-model-using-threejs.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_3d_model_using_threejs.py"
+  },
+  "add-a-3d-model-with-babylonjs": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-with-babylonjs/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-3d-model-with-babylonjs.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_3d_model_with_babylonjs.py"
+  },
+  "add-a-3d-model-with-shadow-using-threejs": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-3d-model-with-shadow-using-threejs/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-3d-model-with-shadow-using-threejs.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_3d_model_with_shadow_using_threejs.py"
+  },
+  "add-a-canvas-source": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-canvas-source/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-canvas-source.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_canvas_source.py"
+  },
+  "add-a-cog-raster-source": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-cog-raster-source/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-cog-raster-source.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_cog_raster_source.py"
+  },
+  "add-a-color-relief-layer": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-color-relief-layer/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-color-relief-layer.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_color_relief_layer.py"
+  },
+  "add-a-custom-layer-with-tiles-to-a-globe": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-custom-layer-with-tiles-to-a-globe/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-custom-layer-with-tiles-to-a-globe.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_custom_layer_with_tiles_to_a_globe.py"
+  },
+  "add-a-custom-style-layer": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-custom-style-layer/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-custom-style-layer.html",
+    "task_status": true,
+    "script": null,
+    "notes": "Skipped: Requires custom WebGL layer, which is not yet supported."
+  },
+  "add-a-default-marker": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-default-marker/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-default-marker.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_default_marker.py"
+  },
+  "add-a-generated-icon-to-the-map": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-generated-icon-to-the-map/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-generated-icon-to-the-map.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_generated_icon_to_the_map.py"
+  },
+  "add-a-geojson-line": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-geojson-line/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-geojson-line.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_geojson_line.py"
+  },
+  "add-a-geojson-polygon": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-geojson-polygon/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-geojson-polygon.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_geojson_polygon.py"
+  },
+  "add-a-hillshade-layer": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-hillshade-layer/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-hillshade-layer.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_hillshade_layer.py"
+  },
+  "add-a-multidirectional-hillshade-layer": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-multidirectional-hillshade-layer/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-multidirectional-hillshade-layer.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_multidirectional_hillshade_layer.py"
+  },
+  "add-a-new-layer-below-labels": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-new-layer-below-labels/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-new-layer-below-labels.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_new_layer_below_labels.py"
+  },
+  "add-a-pattern-to-a-polygon": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-pattern-to-a-polygon/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-pattern-to-a-polygon.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_pattern_to_a_polygon.py"
+  },
+  "add-a-raster-tile-source": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-raster-tile-source/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-raster-tile-source.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_raster_tile_source.py"
+  },
+  "add-a-simple-custom-layer-on-a-globe": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-simple-custom-layer-on-a-globe/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-simple-custom-layer-on-a-globe.html",
+    "task_status": true,
+    "script": null,
+    "notes": "Skipped: Requires custom WebGL layer, which is not yet supported."
+  },
+  "add-a-stretchable-image-to-the-map": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-stretchable-image-to-the-map/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-stretchable-image-to-the-map.html",
+    "task_status": true,
+    "script": null
+  },
+  "add-a-vector-tile-source": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-vector-tile-source/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-vector-tile-source.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_vector_tile_source.py"
+  },
+  "add-a-video": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-video/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-video.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_video.py"
+  },
+  "add-a-wms-source": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-a-wms-source/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-a-wms-source.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_a_wms_source.py"
+  },
+  "add-an-animated-icon-to-the-map": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-an-animated-icon-to-the-map/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-an-animated-icon-to-the-map.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_an_animated_icon_to_the_map.py"
+  },
+  "add-an-icon-to-the-map": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-an-icon-to-the-map/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-an-icon-to-the-map.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_an_icon_to_the_map.py"
+  },
+  "add-contour-lines": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-contour-lines/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-contour-lines.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_contour_lines.py"
+  },
+  "add-custom-icons-with-markers": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-custom-icons-with-markers/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-custom-icons-with-markers.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_custom_icons_with_markers.py"
+  },
+  "add-live-realtime-data": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-live-realtime-data/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-live-realtime-data.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_live_realtime_data.py"
+  },
+  "add-multiple-geometries-from-one-geojson-source": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-multiple-geometries-from-one-geojson-source/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-multiple-geometries-from-one-geojson-source.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_multiple_geometries_from_one_geojson_source.py"
+  },
+  "add-support-for-right-to-left-scripts": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/add-support-for-right-to-left-scripts/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/add-support-for-right-to-left-scripts.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_add_support_for_right_to_left_scripts.py"
+  },
+  "adding-3d-models-using-threejs-on-terrain": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/adding-3d-models-using-threejs-on-terrain/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/adding-3d-models-using-threejs-on-terrain.html",
+    "task_status": false,
+    "script": null
+  },
+  "animate-a-line": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-line/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/animate-a-line.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_animate_a_line.py"
+  },
+  "animate-a-marker": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-marker/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/animate-a-marker.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_animate_a_marker.py"
+  },
+  "animate-a-point": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/animate-a-point.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_animate_a_point.py"
+  },
+  "animate-a-point-along-a-route": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-point-along-a-route/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/animate-a-point-along-a-route.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_animate_a_point_along_a_route.py"
+  },
+  "animate-a-series-of-images": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-a-series-of-images/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/animate-a-series-of-images.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_animate_a_series_of_images.py"
+  },
+  "animate-map-camera-around-a-point": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-map-camera-around-a-point/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/animate-map-camera-around-a-point.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_animate_map_camera_around_a_point.py"
+  },
+  "animate-symbol-to-follow-the-mouse": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/animate-symbol-to-follow-the-mouse/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/animate-symbol-to-follow-the-mouse.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_animate_symbol_to_follow_the_mouse.py"
+  },
+  "attach-a-popup-to-a-marker-instance": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/attach-a-popup-to-a-marker-instance/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/attach-a-popup-to-a-marker-instance.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_attach_a_popup_to_a_marker_instance.py"
+  },
+  "center-the-map-on-a-clicked-symbol": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/center-the-map-on-a-clicked-symbol/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/center-the-map-on-a-clicked-symbol.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_center_the_map_on_a_clicked_symbol.py"
+  },
+  "change-a-layers-color-with-buttons": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-a-layers-color-with-buttons/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/change-a-layers-color-with-buttons.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_change_a_layers_color_with_buttons.py"
+  },
+  "change-a-maps-language": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-a-maps-language/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/change-a-maps-language.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_change_a_maps_language.py"
+  },
+  "change-building-color-based-on-zoom-level": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-building-color-based-on-zoom-level/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/change-building-color-based-on-zoom-level.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_change_building_color_based_on_zoom_level.py"
+  },
+  "change-the-case-of-labels": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-the-case-of-labels/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/change-the-case-of-labels.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_change_the_case_of_labels.py"
+  },
+  "change-the-default-position-for-attribution": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/change-the-default-position-for-attribution/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/change-the-default-position-for-attribution.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_change_the_default_position_for_attribution.py"
+  },
+  "check-if-webgl-is-supported": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/check-if-webgl-is-supported/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/check-if-webgl-is-supported.html",
+    "task_status": false,
+    "script": null
+  },
+  "cooperative-gestures": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/cooperative-gestures/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/cooperative-gestures.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_cooperative_gestures.py"
+  },
+  "create-a-draggable-marker": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-draggable-marker/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/create-a-draggable-marker.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_create_a_draggable_marker.py"
+  },
+  "create-a-draggable-point": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-draggable-point/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/create-a-draggable-point.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_create_a_draggable_point.py"
+  },
+  "create-a-gradient-line-using-an-expression": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-gradient-line-using-an-expression/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/create-a-gradient-line-using-an-expression.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_create_a_gradient_line_using_an_expression.py"
+  },
+  "create-a-heatmap-layer": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-heatmap-layer/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/create-a-heatmap-layer.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_create_a_heatmap_layer.py"
+  },
+  "create-a-heatmap-layer-on-a-globe-with-terrain-elevation": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-heatmap-layer-on-a-globe-with-terrain-elevation/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/create-a-heatmap-layer-on-a-globe-with-terrain-elevation.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_create_a_heatmap_layer_on_a_globe_with_terrain_elevation.py"
+  },
+  "create-a-hover-effect": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-hover-effect/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/create-a-hover-effect.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_create_a_hover_effect.py"
+  },
+  "create-a-time-slider": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-a-time-slider/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/create-a-time-slider.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_create_a_time_slider.py"
+  },
+  "create-and-style-clusters": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-and-style-clusters/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/create-and-style-clusters.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_create_and_style_clusters.py"
+  },
+  "create-deckgl-layer-using-rest-api": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-deckgl-layer-using-rest-api/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/create-deckgl-layer-using-rest-api.html",
+    "task_status": false,
+    "script": null
+  },
+  "customize-camera-animations": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/customize-camera-animations/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/customize-camera-animations.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_customize_camera_animations.py"
+  },
+  "disable-map-rotation": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/disable-map-rotation/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/disable-map-rotation.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_disable_map_rotation.py"
+  },
+  "disable-scroll-zoom": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/disable-scroll-zoom/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/disable-scroll-zoom.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_disable_scroll_zoom.py"
+  },
+  "display-a-globe-with-a-fill-extrusion-layer": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-a-fill-extrusion-layer/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-a-globe-with-a-fill-extrusion-layer.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_a_globe_with_a_fill_extrusion_layer.py"
+  },
+  "display-a-globe-with-a-vector-map": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-a-vector-map/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-a-globe-with-a-vector-map.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_a_globe_with_a_vector_map.py"
+  },
+  "display-a-globe-with-an-atmosphere": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-globe-with-an-atmosphere/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-a-globe-with-an-atmosphere.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_a_globe_with_an_atmosphere.py"
+  },
+  "display-a-hybrid-satellite-map-with-terrain-elevation": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-hybrid-satellite-map-with-terrain-elevation/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-a-hybrid-satellite-map-with-terrain-elevation.html",
+    "task_status": false,
+    "script": null
+  },
+  "display-a-map": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-map/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-a-map.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_a_map.py"
+  },
+  "display-a-non-interactive-map": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-non-interactive-map/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-a-non-interactive-map.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_a_non_interactive_map.py"
+  },
+  "display-a-popup": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-a-popup.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_a_popup.py"
+  },
+  "display-a-popup-on-click": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup-on-click/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-a-popup-on-click.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_a_popup_on_click.py"
+  },
+  "display-a-popup-on-hover": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-popup-on-hover/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-a-popup-on-hover.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_a_popup_on_hover.py"
+  },
+  "display-a-remote-svg-symbol": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-remote-svg-symbol/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-a-remote-svg-symbol.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_a_remote_svg_symbol.py"
+  },
+  "display-a-satellite-map": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-a-satellite-map/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-a-satellite-map.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_a_satellite_map.py"
+  },
+  "display-and-style-rich-text-labels": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-and-style-rich-text-labels/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-and-style-rich-text-labels.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_and_style_rich_text_labels.py"
+  },
+  "display-buildings-in-3d": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-buildings-in-3d/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-buildings-in-3d.html",
+    "task_status": false,
+    "script": null
+  },
+  "display-html-clusters-with-custom-properties": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-html-clusters-with-custom-properties/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-html-clusters-with-custom-properties.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_html_clusters_with_custom_properties.py"
+  },
+  "display-line-that-crosses-180th-meridian": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-line-that-crosses-180th-meridian/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-line-that-crosses-180th-meridian.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_line_that_crosses_180th_meridian.py"
+  },
+  "display-map-navigation-controls": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/display-map-navigation-controls/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/display-map-navigation-controls.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_display_map_navigation_controls.py"
+  },
+  "draw-a-circle": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-a-circle/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/draw-a-circle.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_draw_a_circle.py"
+  },
+  "draw-geojson-points": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-geojson-points/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/draw-geojson-points.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_draw_geojson_points.py"
+  },
+  "draw-geometries-with-terra-draw": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-geometries-with-terra-draw/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/draw-geometries-with-terra-draw.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_draw_geometries_with_terra_draw.py"
+  },
+  "draw-polygon-with-mapbox-gl-draw": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/draw-polygon-with-mapbox-gl-draw/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/draw-polygon-with-mapbox-gl-draw.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_draw_polygon_with_mapbox_gl_draw.py"
+  },
+  "extrude-polygons-for-3d-indoor-mapping": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/extrude-polygons-for-3d-indoor-mapping/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/extrude-polygons-for-3d-indoor-mapping.html",
+    "task_status": false,
+    "script": null
+  },
+  "filter-layer-symbols-using-global-state": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-layer-symbols-using-global-state/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/filter-layer-symbols-using-global-state.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_filter_layer_symbols_using_global_state.py"
+  },
+  "filter-symbols-by-text-input": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-symbols-by-text-input/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/filter-symbols-by-text-input.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_filter_symbols_by_text_input.py"
+  },
+  "filter-symbols-by-toggling-a-list": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-symbols-by-toggling-a-list/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/filter-symbols-by-toggling-a-list.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_filter_symbols_by_toggling_a_list.py"
+  },
+  "filter-within-a-layer": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-within-a-layer/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/filter-within-a-layer.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_filter_within_a_layer.py"
+  },
+  "fit-a-map-to-a-bounding-box": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fit-a-map-to-a-bounding-box/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/fit-a-map-to-a-bounding-box.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_fit_a_map_to_a_bounding_box.py"
+  },
+  "fit-to-the-bounds-of-a-linestring": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fit-to-the-bounds-of-a-linestring/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/fit-to-the-bounds-of-a-linestring.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_fit_to_the_bounds_of_a_linestring.py"
+  },
+  "fly-to-a-location": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fly-to-a-location/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/fly-to-a-location.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_fly_to_a_location.py"
+  },
+  "fly-to-a-location-based-on-scroll-position": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/fly-to-a-location-based-on-scroll-position/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/fly-to-a-location-based-on-scroll-position.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_fly_to_a_location_based_on_scroll_position.py"
+  },
+  "generate-and-add-a-missing-icon-to-the-map": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/generate-and-add-a-missing-icon-to-the-map/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/generate-and-add-a-missing-icon-to-the-map.html",
+    "task_status": false,
+    "script": null
+  },
+  "geocode-with-nominatim": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/geocode-with-nominatim/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/geocode-with-nominatim.html",
+    "task_status": false,
+    "script": null
+  },
+  "get-coordinates-of-the-mouse-pointer": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/get-coordinates-of-the-mouse-pointer/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/get-coordinates-of-the-mouse-pointer.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_get_coordinates_of_the_mouse_pointer.py"
+  },
+  "get-features-under-the-mouse-pointer": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/get-features-under-the-mouse-pointer/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/get-features-under-the-mouse-pointer.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_get_features_under_the_mouse_pointer.py"
+  },
+  "hash-routing": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/hash-routing/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/hash-routing.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_hash_routing.py"
+  },
+  "jump-to-a-series-of-locations": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/jump-to-a-series-of-locations/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/jump-to-a-series-of-locations.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_jump_to_a_series_of_locations.py"
+  },
+  "level-of-detail-control": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/level-of-detail-control/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/level-of-detail-control.html",
+    "task_status": false,
+    "script": null
+  },
+  "locate-the-user": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/locate-the-user/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/locate-the-user.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_locate_the_user.py"
+  },
+  "measure-distances": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/measure-distances/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/measure-distances.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_measure_distances.py"
+  },
+  "navigate-the-map-with-game-like-controls": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/navigate-the-map-with-game-like-controls/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/navigate-the-map-with-game-like-controls.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_navigate_the_map_with_game_like_controls.py"
+  },
+  "offset-the-vanishing-point-using-padding": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/offset-the-vanishing-point-using-padding/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/offset-the-vanishing-point-using-padding.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_offset_the_vanishing_point_using_padding.py"
+  },
+  "pmtiles-source-and-protocol": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/pmtiles-source-and-protocol/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/pmtiles-source-and-protocol.html",
+    "task_status": false,
+    "script": null
+  },
+  "render-world-copies": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/render-world-copies/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/render-world-copies.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_render_world_copies.py"
+  },
+  "restrict-map-panning-to-an-area": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/restrict-map-panning-to-an-area/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/restrict-map-panning-to-an-area.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_restrict_map_panning_to_an_area.py"
+  },
+  "set-center-point-above-ground": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/set-center-point-above-ground/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/set-center-point-above-ground.html",
+    "task_status": false,
+    "script": null
+  },
+  "set-pitch-and-bearing": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/set-pitch-and-bearing/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/set-pitch-and-bearing.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_set_pitch_and_bearing.py"
+  },
+  "show-polygon-information-on-click": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/show-polygon-information-on-click/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/show-polygon-information-on-click.html",
+    "task_status": false,
+    "script": null
+  },
+  "sky-fog-terrain": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/sky-fog-terrain/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/sky-fog-terrain.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_sky_fog_terrain.py"
+  },
+  "slowly-fly-to-a-location": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/slowly-fly-to-a-location/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/slowly-fly-to-a-location.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_slowly_fly_to_a_location.py"
+  },
+  "style-lines-with-a-data-driven-property": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/style-lines-with-a-data-driven-property/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/style-lines-with-a-data-driven-property.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_style_lines_with_a_data_driven_property.py"
+  },
+  "sync-movement-of-multiple-maps": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/sync-movement-of-multiple-maps/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/sync-movement-of-multiple-maps.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_sync_movement_of_multiple_maps.py"
+  },
+  "toggle-deckgl-layer": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-deckgl-layer/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/toggle-deckgl-layer.html",
+    "task_status": false,
+    "script": null
+  },
+  "toggle-interactions": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-interactions/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/toggle-interactions.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_toggle_interactions.py"
+  },
+  "update-a-feature-in-realtime": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/update-a-feature-in-realtime/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/update-a-feature-in-realtime.html",
+    "task_status": false,
+    "script": null
+  },
+  "use-a-fallback-image": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-a-fallback-image/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/use-a-fallback-image.html",
+    "task_status": false,
+    "script": null
+  },
+  "use-addprotocol-to-transform-feature-properties": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-addprotocol-to-transform-feature-properties/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/use-addprotocol-to-transform-feature-properties.html",
+    "task_status": false,
+    "script": null
+  },
+  "use-locally-generated-ideographs": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-locally-generated-ideographs/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/use-locally-generated-ideographs.html",
+    "task_status": false,
+    "script": null
+  },
+  "variable-label-placement": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/variable-label-placement.html",
+    "task_status": false,
+    "script": null
+  },
+  "variable-label-placement-with-offset": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement-with-offset/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/variable-label-placement-with-offset.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_variable_label_placement_with_offset.py"
+  },
+  "view-a-fullscreen-map": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-a-fullscreen-map/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/view-a-fullscreen-map.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_view_a_fullscreen_map.py"
+  },
+  "view-local-geojson": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-local-geojson/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/view-local-geojson.html",
+    "task_status": false,
+    "script": null
+  },
+  "view-local-geojson-experimental": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-local-geojson-experimental/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/view-local-geojson-experimental.html",
+    "task_status": false,
+    "script": null
+  },
+  "visualize-population-density": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/visualize-population-density.html",
+    "task_status": true,
+    "script": "tests/test_examples/test_visualize_population_density.py"
+  },
+  "zoom-and-planet-size-relation-on-globe": {
+    "url": "https://maplibre.org/maplibre-gl-js/docs/examples/zoom-and-planet-size-relation-on-globe/",
+    "source_status": true,
+    "file_path": "misc/maplibre_examples/pages/zoom-and-planet-size-relation-on-globe.html",
+    "task_status": false,
+    "script": null
+  }
 }

--- a/tests/test_examples/test_change_a_layers_color_with_buttons.py
+++ b/tests/test_examples/test_change_a_layers_color_with_buttons.py
@@ -1,0 +1,206 @@
+"""Recreate the change-a-layers-color-with-buttons example."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum import Map
+
+
+def test_change_a_layers_color_with_buttons() -> None:
+    """Allow users to switch fill colors for multiple layers via swatches."""
+
+    features = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"category": "water"},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [12.3325, 45.4375],
+                            [12.3325, 45.4405],
+                            [12.3395, 45.4405],
+                            [12.3395, 45.4375],
+                            [12.3325, 45.4375],
+                        ]
+                    ],
+                },
+            },
+            {
+                "type": "Feature",
+                "properties": {"category": "building"},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [12.3395, 45.4365],
+                            [12.3395, 45.4395],
+                            [12.3445, 45.4395],
+                            [12.3445, 45.4365],
+                            [12.3395, 45.4365],
+                        ]
+                    ],
+                },
+            },
+        ],
+    }
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[12.338, 45.4385],
+        zoom=17.4,
+    )
+
+    map_instance.add_source("venice-landuse", {"type": "geojson", "data": features})
+
+    map_instance.add_layer(
+        {
+            "id": "water",
+            "type": "fill",
+            "paint": {"fill-color": "#41b6c4", "fill-opacity": 0.65},
+            "filter": ["==", ["get", "category"], "water"],
+        },
+        source="venice-landuse",
+    )
+    map_instance.add_layer(
+        {
+            "id": "building-top",
+            "type": "fill",
+            "paint": {"fill-color": "#feb24c", "fill-opacity": 0.85},
+            "filter": ["==", ["get", "category"], "building"],
+        },
+        source="venice-landuse",
+    )
+
+    map_instance.custom_css = textwrap.dedent(
+        """
+        .maplibreum-layer-overlay {
+            font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            width: 220px;
+            background: #fff;
+            padding: 12px;
+            border-radius: 4px;
+            box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+        }
+
+        .maplibreum-layer-overlay label {
+            font-weight: 600;
+            display: block;
+            margin-bottom: 6px;
+        }
+
+        .maplibreum-layer-overlay select {
+            width: 100%;
+            margin-bottom: 10px;
+        }
+
+        .maplibreum-layer-overlay .swatch-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .maplibreum-layer-overlay button.maplibreum-swatch {
+            width: 32px;
+            height: 20px;
+            border: none;
+            border-radius: 3px;
+            cursor: pointer;
+        }
+
+        .maplibreum-layer-overlay button.maplibreum-swatch:focus {
+            outline: none;
+        }
+        """
+    ).strip()
+
+    palette = [
+        "#ffffcc",
+        "#a1dab4",
+        "#41b6c4",
+        "#2c7fb8",
+        "#253494",
+        "#fed976",
+        "#feb24c",
+        "#fd8d3c",
+        "#f03b20",
+        "#bd0026",
+    ]
+
+    controls_js = textwrap.dedent(
+        """
+        var overlay = document.createElement('div');
+        overlay.id = 'maplibreum-layer-controls';
+        overlay.className = 'maplibreum-layer-overlay';
+
+        var label = document.createElement('label');
+        label.htmlFor = 'maplibreum-layer-select';
+        label.textContent = 'Select layer';
+        overlay.appendChild(label);
+
+        var select = document.createElement('select');
+        select.id = 'maplibreum-layer-select';
+        [
+            { id: 'water', title: 'Water' },
+            { id: 'building-top', title: 'Buildings' }
+        ].forEach(function(entry) {
+            var option = document.createElement('option');
+            option.value = entry.id;
+            option.textContent = entry.title;
+            select.appendChild(option);
+        });
+        overlay.appendChild(select);
+
+        var swatchLabel = document.createElement('label');
+        swatchLabel.textContent = 'Choose a color';
+        overlay.appendChild(swatchLabel);
+
+        var swatchRow = document.createElement('div');
+        swatchRow.className = 'swatch-row';
+        overlay.appendChild(swatchRow);
+
+        var colors = %s;
+
+        colors.forEach(function(color) {
+            var button = document.createElement('button');
+            button.className = 'maplibreum-swatch';
+            button.type = 'button';
+            button.style.backgroundColor = color;
+            button.addEventListener('click', function() {
+                var targetLayer = select.value;
+                map.setPaintProperty(targetLayer, 'fill-color', color);
+            });
+            swatchRow.appendChild(button);
+        });
+
+        map.getContainer().appendChild(overlay);
+        """
+    ) % textwrap.dedent(textwrap.indent(str(palette), ""))
+    map_instance.add_on_load_js(controls_js.strip())
+
+    assert len(map_instance.layers) == 2
+    layer_definitions = {layer["id"]: layer["definition"] for layer in map_instance.layers}
+    assert "water" in layer_definitions
+    assert "building-top" in layer_definitions
+    assert layer_definitions["water"]["filter"] == ["==", ["get", "category"], "water"]
+    assert layer_definitions["building-top"]["filter"] == [
+        "==",
+        ["get", "category"],
+        "building",
+    ]
+
+    assert map_instance._on_load_callbacks, "Expected on-load JavaScript for button wiring"
+    on_load_js = "\n".join(map_instance._on_load_callbacks)
+    assert "map.setPaintProperty" in on_load_js
+    assert "maplibreum-layer-select" in on_load_js
+
+    html = map_instance.render()
+    assert "maplibreum-layer-overlay" in html
+    for color in ("#fd8d3c", "#253494"):
+        assert color in html

--- a/tests/test_examples/test_change_a_maps_language.py
+++ b/tests/test_examples/test_change_a_maps_language.py
@@ -1,0 +1,173 @@
+"""Reproduce the change-a-maps-language example."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum import Map
+
+
+COUNTRY_FEATURES = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "name:en": "Austria",
+                "name:fr": "Autriche",
+                "name:ru": "Австрия",
+                "name:de": "Österreich",
+                "name:es": "Austria",
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [16.05, 48.2],
+            },
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "name:en": "Hungary",
+                "name:fr": "Hongrie",
+                "name:ru": "Венгрия",
+                "name:de": "Ungarn",
+                "name:es": "Hungría",
+            },
+            "geometry": {"type": "Point", "coordinates": [19.05, 47.5]},
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "name:en": "Germany",
+                "name:fr": "Allemagne",
+                "name:ru": "Германия",
+                "name:de": "Deutschland",
+                "name:es": "Alemania",
+            },
+            "geometry": {"type": "Point", "coordinates": [13.4, 52.52]},
+        },
+    ],
+}
+
+
+LANGUAGE_CODES = ["fr", "ru", "de", "es"]
+
+
+def _base_label_layer(layer_id: str) -> dict:
+    return {
+        "id": layer_id,
+        "type": "symbol",
+        "layout": {
+            "text-field": ["get", "name:en"],
+            "text-font": ["Noto Sans Regular"],
+            "text-size": 13,
+        },
+        "paint": {"text-color": "#333", "text-halo-color": "#fff", "text-halo-width": 1},
+    }
+
+
+def test_change_a_maps_language() -> None:
+    """Dynamically toggle label languages using a button strip."""
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[16.05, 48.0],
+        zoom=3.0,
+    )
+    map_instance.add_source("countries", {"type": "geojson", "data": COUNTRY_FEATURES})
+
+    for index in range(1, 4):
+        layer_id = f"label_country_{index}"
+        definition = _base_label_layer(layer_id)
+        map_instance.add_layer(definition, source="countries")
+
+    map_instance.custom_css = textwrap.dedent(
+        """
+        .maplibreum-language-buttons {
+            position: absolute;
+            top: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            gap: 8px;
+            padding: 6px 10px;
+            list-style: none;
+            background: rgba(0, 0, 0, 0.65);
+            border-radius: 999px;
+            color: #fff;
+            font: 12px/18px 'Helvetica Neue', Arial, sans-serif;
+        }
+
+        .maplibreum-language-buttons button {
+            border: none;
+            background: transparent;
+            color: inherit;
+            cursor: pointer;
+            font-weight: 600;
+            padding: 6px 12px;
+            border-radius: 14px;
+        }
+
+        .maplibreum-language-buttons button:hover,
+        .maplibreum-language-buttons button.is-active {
+            background: #ee8a65;
+        }
+        """
+    ).strip()
+
+    buttons_js = textwrap.dedent(
+        """
+        var container = document.createElement('ul');
+        container.id = 'maplibreum-language-buttons';
+        container.className = 'maplibreum-language-buttons';
+
+        var languages = %s;
+
+        languages.forEach(function(code, index) {
+            var item = document.createElement('li');
+            var button = document.createElement('button');
+            button.type = 'button';
+            button.dataset.language = code;
+            button.textContent = code.toUpperCase();
+            if (index === 0) {
+                button.classList.add('is-active');
+            }
+            item.appendChild(button);
+            container.appendChild(item);
+        });
+
+        container.addEventListener('click', function(event) {
+            var target = event.target;
+            if (!target || !target.dataset || !target.dataset.language) {
+                return;
+            }
+            var language = target.dataset.language;
+            container.querySelectorAll('button').forEach(function(btn) {
+                btn.classList.toggle('is-active', btn === target);
+            });
+            ['label_country_1', 'label_country_2', 'label_country_3'].forEach(function(layerId) {
+                map.setLayoutProperty(layerId, 'text-field', ['get', 'name:' + language]);
+            });
+        });
+
+        map.getContainer().appendChild(container);
+        """
+    ) % textwrap.dedent(textwrap.indent(str(LANGUAGE_CODES), ""))
+    map_instance.add_on_load_js(buttons_js.strip())
+
+    assert len(map_instance.layers) == 3
+    text_fields = {
+        layer["id"]: layer["definition"]["layout"]["text-field"]
+        for layer in map_instance.layers
+    }
+    for key in ("label_country_1", "label_country_2", "label_country_3"):
+        assert text_fields[key] == ["get", "name:en"]
+
+    joined_js = "\n".join(map_instance._on_load_callbacks)
+    assert "map.setLayoutProperty" in joined_js
+    assert "name:" in joined_js
+
+    html = map_instance.render()
+    assert "maplibreum-language-buttons" in html
+    for code in ("fr", "ru", "de", "es"):
+        assert f"'" + code + "'" in html or f'\"{code}\"' in html

--- a/tests/test_examples/test_change_the_case_of_labels.py
+++ b/tests/test_examples/test_change_the_case_of_labels.py
@@ -1,0 +1,72 @@
+"""Test replicating the change-the-case-of-labels example."""
+
+from __future__ import annotations
+
+from maplibreum import Map
+
+
+def test_change_the_case_of_labels() -> None:
+    """Use upcase and downcase expressions for symbol labels."""
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-116.231, 43.604],
+        zoom=11,
+    )
+
+    boise_dog_parks = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {
+                    "FacilityName": "Together Treasure Valley Dog Island",
+                    "Comments": "Large off-leash park",
+                },
+                "geometry": {"type": "Point", "coordinates": [-116.246, 43.62]},
+            },
+            {
+                "type": "Feature",
+                "properties": {
+                    "FacilityName": "Morris Hill Park",
+                    "Comments": "Shaded agility area",
+                },
+                "geometry": {"type": "Point", "coordinates": [-116.22, 43.6]},
+            },
+        ],
+    }
+
+    map_instance.add_source("off-leash-areas", {"type": "geojson", "data": boise_dog_parks})
+    map_instance.add_layer(
+        {
+            "id": "off-leash-areas",
+            "type": "symbol",
+            "layout": {
+                "icon-image": "dog_park",
+                "text-field": [
+                    "format",
+                    ["upcase", ["get", "FacilityName"]],
+                    {"font-scale": 0.8},
+                    "\n",
+                    {},
+                    ["downcase", ["get", "Comments"]],
+                    {"font-scale": 0.6},
+                ],
+                "text-font": ["Noto Sans Regular"],
+                "text-offset": [0, 0.6],
+                "text-anchor": "top",
+            },
+        },
+        source="off-leash-areas",
+    )
+
+    assert len(map_instance.layers) == 1
+    layer_definition = map_instance.layers[0]["definition"]
+    assert layer_definition["layout"]["text-field"][0] == "format"
+    assert ["upcase", ["get", "FacilityName"]] in layer_definition["layout"]["text-field"]
+    assert ["downcase", ["get", "Comments"]] in layer_definition["layout"]["text-field"]
+
+    html = map_instance.render()
+    assert "FacilityName" in html
+    assert "upcase" in html
+    assert "downcase" in html

--- a/tests/test_examples/test_display_and_style_rich_text_labels.py
+++ b/tests/test_examples/test_display_and_style_rich_text_labels.py
@@ -1,0 +1,79 @@
+"""Validate the display-and-style-rich-text-labels example."""
+
+from __future__ import annotations
+
+from maplibreum import Map
+
+
+COUNTRY_POINTS = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {"name_en": "Italy", "name": "Italia"},
+            "geometry": {"type": "Point", "coordinates": [12.4964, 41.9028]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"name_en": "Spain", "name": "España"},
+            "geometry": {"type": "Point", "coordinates": [-3.7038, 40.4168]},
+        },
+    ],
+}
+
+
+def test_display_and_style_rich_text_labels() -> None:
+    """Apply format expressions with mixed font scales and RTL plugin."""
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[17.49, 40.01],
+        zoom=4,
+    )
+
+    map_instance.enable_rtl_text_plugin(
+        "https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.3.0/dist/mapbox-gl-rtl-text.js"
+    )
+
+    map_instance.add_source("countries", {"type": "geojson", "data": COUNTRY_POINTS})
+    map_instance.add_layer(
+        {
+            "id": "label_country",
+            "type": "symbol",
+            "layout": {
+                "text-field": [
+                    "format",
+                    ["get", "name_en"],
+                    {"font-scale": 1.2},
+                    "\n",
+                    {},
+                    ["get", "name"],
+                    {
+                        "font-scale": 0.8,
+                        "text-font": ["literal", ["Noto Sans Regular"]],
+                    },
+                ],
+                "text-font": ["Noto Sans Regular"],
+                "text-size": 16,
+                "text-anchor": "center",
+            },
+        },
+        source="countries",
+    )
+
+    assert map_instance.rtl_text_plugin is not None
+    assert (
+        map_instance.rtl_text_plugin["url"]
+        == "https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.3.0/dist/mapbox-gl-rtl-text.js"
+    )
+
+    layer_definition = map_instance.layers[0]["definition"]
+    text_field = layer_definition["layout"]["text-field"]
+    assert text_field[0] == "format"
+    assert ["get", "name_en"] in text_field
+    assert ["get", "name"] in text_field
+
+    html = map_instance.render()
+    assert "name_en" in html
+    assert "font-scale" in html
+    assert "rtl-text" in html

--- a/tests/test_examples/test_display_html_clusters_with_custom_properties.py
+++ b/tests/test_examples/test_display_html_clusters_with_custom_properties.py
@@ -1,0 +1,201 @@
+"""Mimic the display-html-clusters-with-custom-properties example."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum import Map
+
+
+def test_display_html_clusters_with_custom_properties() -> None:
+    """Create clustered layers and HTML donut markers that mirror the example."""
+
+    map_instance = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[0, 20],
+        zoom=0.3,
+    )
+    map_instance.add_control("navigation")
+
+    earthquakes_source = {
+        "type": "geojson",
+        "data": "https://maplibre.org/maplibre-gl-js/docs/assets/earthquakes.geojson",
+        "cluster": True,
+        "clusterRadius": 80,
+        "clusterProperties": {
+            "mag1": ["+", ["case", ["<", ["get", "mag"], 2], 1, 0]],
+            "mag2": [
+                "+",
+                [
+                    "case",
+                    ["all", [">=", ["get", "mag"], 2], ["<", ["get", "mag"], 3]],
+                    1,
+                    0,
+                ],
+            ],
+            "mag3": [
+                "+",
+                [
+                    "case",
+                    ["all", [">=", ["get", "mag"], 3], ["<", ["get", "mag"], 4]],
+                    1,
+                    0,
+                ],
+            ],
+            "mag4": [
+                "+",
+                [
+                    "case",
+                    ["all", [">=", ["get", "mag"], 4], ["<", ["get", "mag"], 5]],
+                    1,
+                    0,
+                ],
+            ],
+            "mag5": [
+                "+",
+                ["case", [">=", ["get", "mag"], 5], 1, 0],
+            ],
+        },
+    }
+    map_instance.add_source("earthquakes", earthquakes_source)
+
+    map_instance.add_layer(
+        {
+            "id": "earthquake_circle",
+            "type": "circle",
+            "paint": {
+                "circle-color": [
+                    "case",
+                    ["<", ["get", "mag"], 2],
+                    "#fed976",
+                    ["all", [">=", ["get", "mag"], 2], ["<", ["get", "mag"], 3]],
+                    "#feb24c",
+                    ["all", [">=", ["get", "mag"], 3], ["<", ["get", "mag"], 4]],
+                    "#fd8d3c",
+                    ["all", [">=", ["get", "mag"], 4], ["<", ["get", "mag"], 5]],
+                    "#fc4e2a",
+                    "#e31a1c",
+                ],
+                "circle-opacity": 0.6,
+                "circle-radius": 12,
+            },
+            "filter": ["!=", "cluster", True],
+        },
+        source="earthquakes",
+    )
+    map_instance.add_layer(
+        {
+            "id": "earthquake_label",
+            "type": "symbol",
+            "layout": {
+                "text-field": [
+                    "number-format",
+                    ["get", "mag"],
+                    {"min-fraction-digits": 1, "max-fraction-digits": 1},
+                ],
+                "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
+                "text-size": 10,
+            },
+            "paint": {
+                "text-color": [
+                    "case",
+                    ["<", ["get", "mag"], 3],
+                    "black",
+                    "white",
+                ]
+            },
+            "filter": ["!=", "cluster", True],
+        },
+        source="earthquakes",
+    )
+
+    donut_js = textwrap.dedent(
+        """
+        var donutColors = ['#fed976', '#feb24c', '#fd8d3c', '#fc4e2a', '#e31a1c'];
+        var markers = {};
+        var markersOnScreen = {};
+
+        function updateMarkers() {
+            var newMarkers = {};
+            var features = map.querySourceFeatures('earthquakes');
+            for (var i = 0; i < features.length; i++) {
+                var feature = features[i];
+                if (!feature.properties.cluster) { continue; }
+                var id = feature.properties.cluster_id;
+                var marker = markers[id];
+                if (!marker) {
+                    var element = createDonutChart(feature.properties);
+                    marker = markers[id] = new maplibregl.Marker({ element: element }).setLngLat(feature.geometry.coordinates);
+                }
+                newMarkers[id] = marker;
+                if (!markersOnScreen[id]) {
+                    marker.addTo(map);
+                }
+            }
+            for (var existingId in markersOnScreen) {
+                if (!newMarkers[existingId]) {
+                    markersOnScreen[existingId].remove();
+                }
+            }
+            markersOnScreen = newMarkers;
+        }
+
+        map.on('data', function(event) {
+            if (event.sourceId !== 'earthquakes' || !event.isSourceLoaded) {
+                return;
+            }
+            map.on('move', updateMarkers);
+            map.on('moveend', updateMarkers);
+            updateMarkers();
+        });
+
+        function createDonutChart(properties) {
+            var counts = [properties.mag1, properties.mag2, properties.mag3, properties.mag4, properties.mag5];
+            var offsets = [];
+            var total = 0;
+            for (var i = 0; i < counts.length; i++) {
+                offsets.push(total);
+                total += counts[i];
+            }
+            var fontSize = total >= 1000 ? 22 : total >= 100 ? 20 : total >= 10 ? 18 : 16;
+            var radius = total >= 1000 ? 50 : total >= 100 ? 32 : total >= 10 ? 24 : 18;
+            var inner = Math.round(radius * 0.6);
+            var width = radius * 2;
+            var svg = '<div><svg width="' + width + '" height="' + width + '" viewBox="0 0 ' + width + ' ' + width + '" text-anchor="middle" style="font: ' + fontSize + 'px sans-serif; display: block">';
+            for (var j = 0; j < counts.length; j++) {
+                svg += donutSegment(offsets[j] / total, (offsets[j] + counts[j]) / total, radius, inner, donutColors[j]);
+            }
+            svg += '<circle cx="' + radius + '" cy="' + radius + '" r="' + inner + '" fill="white" />';
+            svg += '<text dominant-baseline="central" transform="translate(' + radius + ', ' + radius + ')">' + total + '</text>';
+            svg += '</svg></div>';
+            var container = document.createElement('div');
+            container.innerHTML = svg;
+            return container.firstChild;
+        }
+
+        function donutSegment(start, end, radius, innerRadius, color) {
+            if (end - start === 0) {
+                return '';
+            }
+            var a0 = 2 * Math.PI * (start - 0.25);
+            var a1 = 2 * Math.PI * (end - 0.25);
+            var x0 = Math.cos(a0), y0 = Math.sin(a0);
+            var x1 = Math.cos(a1), y1 = Math.sin(a1);
+            var largeArc = end - start > 0.5 ? 1 : 0;
+            return '<path d="M ' + radius * x0 + ' ' + radius * y0 + ' A ' + radius + ' ' + radius + ' 0 ' + largeArc + ' 1 ' + radius * x1 + ' ' + radius * y1 + ' L ' + innerRadius * x1 + ' ' + innerRadius * y1 + ' A ' + innerRadius + ' ' + innerRadius + ' 0 ' + largeArc + ' 0 ' + innerRadius * x0 + ' ' + innerRadius * y0 + ' Z" fill="' + color + '" />';
+        }
+        """
+    ).strip()
+    map_instance.add_on_load_js(donut_js)
+
+    source_lookup = {
+        source["name"]: source["definition"] for source in map_instance.sources
+    }
+    assert source_lookup["earthquakes"]["cluster"] is True
+    assert "clusterProperties" in source_lookup["earthquakes"]
+    assert source_lookup["earthquakes"]["clusterProperties"]["mag3"][0] == "+"
+
+    html = map_instance.render()
+    assert "donutSegment" in html
+    assert "map.querySourceFeatures('earthquakes')" in html
+    assert "clusterProperties" in html

--- a/tests/test_examples/test_filter_layer_symbols_using_global_state.py
+++ b/tests/test_examples/test_filter_layer_symbols_using_global_state.py
@@ -1,0 +1,118 @@
+"""Exercise the filter-layer-symbols-using-global-state example."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum import Map
+
+
+def test_filter_layer_symbols_using_global_state() -> None:
+    """Toggle symbol visibility based on a select element and global state."""
+
+    map_instance = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[9.0679, 45.8822],
+        zoom=9,
+    )
+
+    map_instance.add_source(
+        "railways_and_lifts",
+        {
+            "type": "geojson",
+            "data": "https://maplibre.org/maplibre-gl-js/docs/assets/funicolares-and-funivias-como.json",
+        },
+    )
+
+    filter_expression = [
+        "case",
+        ["==", ["to-string", ["global-state", "type"]], ""],
+        True,
+        ["==", ["get", "type"], ["global-state", "type"]],
+    ]
+
+    map_instance.add_layer(
+        {
+            "id": "railways_and_lifts_labels",
+            "type": "symbol",
+            "layout": {
+                "text-field": "{name}",
+                "text-font": ["Open Sans Semibold"],
+                "text-offset": [0, 1],
+                "text-anchor": "top",
+            },
+            "paint": {
+                "text-color": "#000000",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 2,
+            },
+            "filter": filter_expression,
+        },
+        source="railways_and_lifts",
+    )
+    map_instance.add_layer(
+        {
+            "id": "railways_and_lifts_points",
+            "type": "circle",
+            "paint": {
+                "circle-radius": 5,
+                "circle-color": "#000000",
+            },
+            "filter": filter_expression,
+        },
+        source="railways_and_lifts",
+    )
+
+    map_instance.custom_css = textwrap.dedent(
+        """
+        .maplibreum-type-filter {
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            background: #fff;
+            padding: 10px;
+            border-radius: 4px;
+            box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+            font: 13px/18px 'Helvetica Neue', Arial, sans-serif;
+        }
+        """
+    ).strip()
+
+    control_js = textwrap.dedent(
+        """
+        var fieldset = document.createElement('fieldset');
+        fieldset.className = 'maplibreum-type-filter';
+        var label = document.createElement('label');
+        label.textContent = 'Filter by type';
+        fieldset.appendChild(label);
+        var select = document.createElement('select');
+        select.name = 'type';
+        ['All', 'lift', 'railway'].forEach(function(optionValue, index) {
+            var option = document.createElement('option');
+            option.value = index === 0 ? '' : optionValue;
+            option.textContent = index === 0 ? 'All' : optionValue.replace('-', ' ');
+            if (index === 0) {
+                option.selected = true;
+            }
+            select.appendChild(option);
+        });
+        fieldset.appendChild(select);
+        map.getContainer().appendChild(fieldset);
+        map.setGlobalStateProperty('type', select.value);
+        select.addEventListener('change', function(event) {
+            map.setGlobalStateProperty('type', event.target.value);
+        });
+        """
+    ).strip()
+    map_instance.add_on_load_js(control_js)
+
+    assert len(map_instance.layers) == 2
+    for layer in map_instance.layers:
+        assert layer["definition"]["filter"] == filter_expression
+
+    joined_js = "\n".join(map_instance._on_load_callbacks)
+    assert "setGlobalStateProperty" in joined_js
+
+    html = map_instance.render()
+    assert "maplibreum-type-filter" in html
+    assert "global-state" in html

--- a/tests/test_examples/test_filter_symbols_by_text_input.py
+++ b/tests/test_examples/test_filter_symbols_by_text_input.py
@@ -1,0 +1,148 @@
+"""Port the filter-symbols-by-text-input example to pytest."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum import Map
+
+
+PLACES = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {"icon": "theatre"},
+            "geometry": {"type": "Point", "coordinates": [-77.038659, 38.931567]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "theatre"},
+            "geometry": {"type": "Point", "coordinates": [-77.003168, 38.894651]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "bar"},
+            "geometry": {"type": "Point", "coordinates": [-77.090372, 38.881189]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "bicycle"},
+            "geometry": {"type": "Point", "coordinates": [-77.052477, 38.943951]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.031706, 38.914581]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.020945, 38.878241]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.007481, 38.876516]},
+        },
+    ],
+}
+
+
+def test_filter_symbols_by_text_input() -> None:
+    """Toggle layer visibility when users type icon names into a search input."""
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-77.04, 38.907],
+        zoom=11.15,
+    )
+
+    map_instance.add_source("places", {"type": "geojson", "data": PLACES})
+
+    unique_icons = sorted({feature["properties"]["icon"] for feature in PLACES["features"]})
+    for icon_name in unique_icons:
+        map_instance.add_layer(
+            {
+                "id": f"poi-{icon_name}",
+                "type": "symbol",
+                "layout": {
+                    "icon-image": f"{icon_name}_11",
+                    "icon-overlap": "always",
+                    "text-field": icon_name,
+                    "text-font": ["Noto Sans Regular"],
+                    "text-size": 11,
+                    "text-transform": "uppercase",
+                    "text-letter-spacing": 0.05,
+                    "text-offset": [0, 1.5],
+                },
+                "paint": {
+                    "text-color": "#202",
+                    "text-halo-color": "#fff",
+                    "text-halo-width": 2,
+                },
+                "filter": ["==", ["get", "icon"], icon_name],
+            },
+            source="places",
+        )
+
+    map_instance.custom_css = textwrap.dedent(
+        """
+        .maplibreum-filter-ctrl {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            z-index: 1;
+        }
+
+        .maplibreum-filter-ctrl input[type='search'] {
+            font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+            border: 0;
+            background-color: #fff;
+            margin: 0;
+            color: rgba(0, 0, 0, 0.6);
+            padding: 10px;
+            box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+            border-radius: 3px;
+            width: 200px;
+        }
+        """
+    ).strip()
+
+    control_js = textwrap.dedent(
+        """
+        var container = document.createElement('div');
+        container.className = 'maplibreum-filter-ctrl';
+        var input = document.createElement('input');
+        input.type = 'search';
+        input.id = 'maplibreum-filter-input';
+        input.placeholder = 'Filter by name';
+        container.appendChild(input);
+        map.getContainer().appendChild(container);
+
+        var layerIDs = %s;
+        input.addEventListener('keyup', function(event) {
+            var value = event.target.value.trim().toLowerCase();
+            layerIDs.forEach(function(layerId) {
+                map.setLayoutProperty(
+                    layerId,
+                    'visibility',
+                    layerId.indexOf(value) > -1 ? 'visible' : 'none'
+                );
+            });
+        });
+        """
+    ) % textwrap.dedent(textwrap.indent(str([f"poi-{icon}" for icon in unique_icons]), ""))
+    map_instance.add_on_load_js(control_js.strip())
+
+    assert len(map_instance.layers) == len(unique_icons)
+    for layer in map_instance.layers:
+        assert layer["definition"]["filter"] == ["==", ["get", "icon"], layer["id"].split("poi-")[1]]
+
+    on_load_js = "\n".join(map_instance._on_load_callbacks)
+    assert "map.setLayoutProperty" in on_load_js
+    assert "layerIDs" in on_load_js
+
+    html = map_instance.render()
+    assert "maplibreum-filter-ctrl" in html
+    assert "Filter by name" in html

--- a/tests/test_examples/test_filter_symbols_by_toggling_a_list.py
+++ b/tests/test_examples/test_filter_symbols_by_toggling_a_list.py
@@ -1,0 +1,168 @@
+"""Implement the filter-symbols-by-toggling-a-list gallery example."""
+
+from __future__ import annotations
+
+import textwrap
+
+from maplibreum import Map
+
+
+PLACES = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {"icon": "theatre"},
+            "geometry": {"type": "Point", "coordinates": [-77.038659, 38.931567]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "theatre"},
+            "geometry": {"type": "Point", "coordinates": [-77.003168, 38.894651]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "bar"},
+            "geometry": {"type": "Point", "coordinates": [-77.090372, 38.881189]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "bicycle"},
+            "geometry": {"type": "Point", "coordinates": [-77.052477, 38.943951]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.031706, 38.914581]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.020945, 38.878241]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.007481, 38.876516]},
+        },
+    ],
+}
+
+
+def test_filter_symbols_by_toggling_a_list() -> None:
+    """Replicate checkbox toggles that control symbol visibility by category."""
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-77.04, 38.907],
+        zoom=11.15,
+    )
+
+    map_instance.add_source("places", {"type": "geojson", "data": PLACES})
+
+    unique_icons = sorted({feature["properties"]["icon"] for feature in PLACES["features"]})
+    for icon_name in unique_icons:
+        map_instance.add_layer(
+            {
+                "id": f"poi-{icon_name}",
+                "type": "symbol",
+                "layout": {
+                    "icon-image": f"{icon_name}_11",
+                    "icon-overlap": "always",
+                },
+                "filter": ["==", "icon", icon_name],
+            },
+            source="places",
+        )
+
+    map_instance.custom_css = textwrap.dedent(
+        """
+        .maplibreum-filter-group {
+            font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+            font-weight: 600;
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            z-index: 1;
+            border-radius: 3px;
+            width: 140px;
+            color: #fff;
+        }
+
+        .maplibreum-filter-group input[type='checkbox'] {
+            display: none;
+        }
+
+        .maplibreum-filter-group input[type='checkbox'] + label {
+            background-color: #3386c0;
+            display: block;
+            cursor: pointer;
+            padding: 10px;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+            text-transform: capitalize;
+        }
+
+        .maplibreum-filter-group input[type='checkbox']:first-child + label {
+            border-radius: 3px 3px 0 0;
+        }
+
+        .maplibreum-filter-group label:last-child {
+            border-radius: 0 0 3px 3px;
+            border: none;
+        }
+
+        .maplibreum-filter-group input[type='checkbox']:checked + label,
+        .maplibreum-filter-group input[type='checkbox'] + label:hover {
+            background-color: #4ea0da;
+        }
+
+        .maplibreum-filter-group input[type='checkbox']:checked + label:before {
+            content: '✔';
+            margin-right: 5px;
+        }
+        """
+    ).strip()
+
+    control_js = textwrap.dedent(
+        """
+        var container = document.createElement('nav');
+        container.id = 'maplibreum-filter-group';
+        container.className = 'maplibreum-filter-group';
+        var layers = %s;
+        layers.forEach(function(layerId, index) {
+            var checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.id = layerId;
+            checkbox.checked = true;
+            container.appendChild(checkbox);
+
+            var label = document.createElement('label');
+            label.setAttribute('for', layerId);
+            label.textContent = layerId.replace('poi-', '');
+            container.appendChild(label);
+
+            checkbox.addEventListener('change', function(event) {
+                map.setLayoutProperty(
+                    layerId,
+                    'visibility',
+                    event.target.checked ? 'visible' : 'none'
+                );
+            });
+        });
+        map.getContainer().appendChild(container);
+        """
+    ) % textwrap.dedent(textwrap.indent(str([f"poi-{icon}" for icon in unique_icons]), ""))
+    map_instance.add_on_load_js(control_js.strip())
+
+    assert len(map_instance.layers) == len(unique_icons)
+    for layer in map_instance.layers:
+        assert layer["definition"]["filter"] == ["==", "icon", layer["id"].replace("poi-", "")]
+
+    joined_js = "\n".join(map_instance._on_load_callbacks)
+    assert "map.setLayoutProperty" in joined_js
+    assert "checkbox" in joined_js
+
+    html = map_instance.render()
+    assert "maplibreum-filter-group" in html
+    for icon in unique_icons:
+        assert icon in html

--- a/tests/test_examples/test_variable_label_placement_with_offset.py
+++ b/tests/test_examples/test_variable_label_placement_with_offset.py
@@ -1,0 +1,94 @@
+"""Test the variable-label-placement-with-offset gallery example."""
+
+from __future__ import annotations
+
+from maplibreum import Map
+
+
+PLACES = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {"description": "Ford's Theater", "icon": "theatre"},
+            "geometry": {"type": "Point", "coordinates": [-77.038659, 38.931567]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "The Gaslight", "icon": "theatre"},
+            "geometry": {"type": "Point", "coordinates": [-77.003168, 38.894651]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "Horrible Harry's", "icon": "bar"},
+            "geometry": {"type": "Point", "coordinates": [-77.090372, 38.881189]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "Bike Party", "icon": "bicycle"},
+            "geometry": {"type": "Point", "coordinates": [-77.052477, 38.943951]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "Rockabilly Rockstars", "icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.031706, 38.914581]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "District Drum Tribe", "icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.020945, 38.878241]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "Motown Memories", "icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.007481, 38.876516]},
+        },
+    ],
+}
+
+
+def test_variable_label_placement_with_offset() -> None:
+    """Allow labels to shift using text-variable-anchor-offset and animate the camera."""
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-77.04, 38.907],
+        zoom=11.15,
+    )
+
+    map_instance.add_source("places", {"type": "geojson", "data": PLACES})
+    map_instance.add_layer(
+        {
+            "id": "poi-labels",
+            "type": "symbol",
+            "layout": {
+                "text-field": ["get", "description"],
+                "text-font": ["Noto Sans Regular"],
+                "text-variable-anchor-offset": [
+                    "top",
+                    [0, 1],
+                    "bottom",
+                    [0, -2],
+                    "left",
+                    [1, 0],
+                    "right",
+                    [-2, 0],
+                ],
+                "text-justify": "auto",
+                "icon-image": ["get", "icon"],
+            },
+        },
+        source="places",
+    )
+
+    map_instance.add_on_load_js("map.rotateTo(180, {duration: 10000});")
+
+    assert len(map_instance.layers) == 1
+    layout = map_instance.layers[0]["definition"]["layout"]
+    assert layout["text-field"] == ["get", "description"]
+    assert layout["text-variable-anchor-offset"][0] == "top"
+    assert ["get", "icon"] == layout["icon-image"]
+
+    html = map_instance.render()
+    assert "text-variable-anchor-offset" in html
+    assert "map.rotateTo(180" in html


### PR DESCRIPTION
## Summary
- port MapLibre styling and filtering HTML samples into pytest modules that replicate their data sources, layer definitions, and JavaScript interactions
- validate language switching, color swatches, global state filters, and cluster donut markup via explicit assertions on generated map styles and on-load scripts
- mark the related gallery entries in `status.json` as implemented with their corresponding test module paths

## Testing
- pytest tests/test_examples -k "layers_color or maps_language or case_of_labels or rich_text_labels or html_clusters or filter_layer_symbols or filter_symbols or variable_label"

------
https://chatgpt.com/codex/tasks/task_b_68d75cc11908832fab44a063e71962ab