### PR TITLE
Refine example coverage to use Map API

### DIFF
--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -397,8 +397,8 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/create-deckgl-layer-using-rest-api/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/create-deckgl-layer-using-rest-api.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_create_deckgl_layer_using_rest_api.py"
   },
   "customize-camera-animations": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/customize-camera-animations/",
@@ -628,15 +628,15 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/generate-and-add-a-missing-icon-to-the-map/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/generate-and-add-a-missing-icon-to-the-map.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_generate_and_add_a_missing_icon_to_the_map.py"
   },
   "geocode-with-nominatim": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/geocode-with-nominatim/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/geocode-with-nominatim.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_geocode_with_nominatim.py"
   },
   "get-coordinates-of-the-mouse-pointer": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/get-coordinates-of-the-mouse-pointer/",
@@ -705,8 +705,8 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/pmtiles-source-and-protocol/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/pmtiles-source-and-protocol.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_pmtiles_source_and_protocol.py"
   },
   "render-world-copies": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/render-world-copies/",
@@ -775,8 +775,8 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-deckgl-layer/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/toggle-deckgl-layer.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_toggle_deckgl_layer.py"
   },
   "toggle-interactions": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/toggle-interactions/",
@@ -789,29 +789,29 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/update-a-feature-in-realtime/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/update-a-feature-in-realtime.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_update_a_feature_in_realtime.py"
   },
   "use-a-fallback-image": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-a-fallback-image/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/use-a-fallback-image.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_use_a_fallback_image.py"
   },
   "use-addprotocol-to-transform-feature-properties": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-addprotocol-to-transform-feature-properties/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/use-addprotocol-to-transform-feature-properties.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_use_addprotocol_to_transform_feature_properties.py"
   },
   "use-locally-generated-ideographs": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/use-locally-generated-ideographs/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/use-locally-generated-ideographs.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_use_locally_generated_ideographs.py"
   },
   "variable-label-placement": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement/",
@@ -838,15 +838,15 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-local-geojson/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/view-local-geojson.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_view_local_geojson.py"
   },
   "view-local-geojson-experimental": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/view-local-geojson-experimental/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/view-local-geojson-experimental.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_view_local_geojson.py"
   },
   "visualize-population-density": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/visualize-population-density/",

--- a/tests/test_examples/test_create_deckgl_layer_using_rest_api.py
+++ b/tests/test_examples/test_create_deckgl_layer_using_rest_api.py
@@ -1,0 +1,87 @@
+from maplibreum import Map
+
+
+DECKGL_SCRIPT = "https://unpkg.com/deck.gl@8.9.33/dist.min.js"
+
+
+FETCH_JS = """
+const colorPalette = [
+    [255, 102, 51],
+    [255, 179, 153],
+    [255, 51, 255],
+    [255, 255, 153],
+    [0, 179, 230],
+    [230, 179, 51],
+    [51, 102, 230],
+    [153, 153, 102],
+    [153, 255, 153],
+    [179, 77, 77],
+    [128, 179, 0],
+    [128, 153, 0],
+    [230, 179, 179],
+    [102, 128, 179],
+    [102, 153, 26],
+    [255, 153, 230],
+    [204, 255, 26],
+    [255, 26, 102],
+    [230, 51, 26],
+    [51, 255, 204],
+    [102, 153, 77],
+];
+const limit = 100;
+const parisSights = `https://data.iledefrance.fr/api/explore/v2.1/catalog/datasets/principaux-sites-touristiques-en-ile-de-france0/records?limit=${limit}`;
+map.on('load', async () => {
+    const response = await fetch(parisSights);
+    const responseJSON = await response.json();
+    const layer = new deck.ScatterplotLayer({
+        id: 'scatterplot-layer',
+        data: responseJSON.results,
+        pickable: true,
+        opacity: 0.7,
+        stroked: true,
+        filled: true,
+        radiusMinPixels: 14,
+        radiusMaxPixels: 100,
+        lineWidthMinPixels: 5,
+        getPosition: (d) => [d.geo_point_2d.lon, d.geo_point_2d.lat],
+        getFillColor: (d) => {
+            if ('insee' in d && d.insee.startsWith('75')) {
+                return colorPalette[parseInt(d.insee.substring(3))];
+            }
+            return colorPalette[20];
+        },
+        getLineColor: (d) => [14, 16, 255],
+        onClick: (info) => {
+            const { coordinate, object } = info;
+            const description = `<p>${object.nom_carto || 'Unknown'}</p>`;
+            new maplibregl.Popup().setLngLat(coordinate).setHTML(description).addTo(map);
+        },
+    });
+    const overlay = new deck.MapboxOverlay({ layers: [layer] });
+    map.addControl(overlay);
+});
+"""
+
+
+def test_create_deckgl_layer_using_rest_api():
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/liberty",
+        center=[2.343957, 48.862011],
+        zoom=10.5,
+    )
+
+    m.add_control("navigation", position="top-right")
+    m.add_external_script(DECKGL_SCRIPT)
+    m.add_on_load_js(FETCH_JS)
+
+    html = m.render()
+
+    assert DECKGL_SCRIPT in html
+    assert "ScatterplotLayer" in html
+    assert "MapboxOverlay" in html
+    assert "fetch(parisSights)" in html
+    assert "map.addControl(overlay)" in html
+    assert any(control["type"] == "navigation" for control in m.controls)
+    assert '"style": "https://tiles.openfreemap.org/styles/liberty"' in html.replace("\n", "")
+    assert '"center": [2.343957, 48.862011]' in html
+    assert '"zoom": 10.5' in html

--- a/tests/test_examples/test_generate_and_add_a_missing_icon_to_the_map.py
+++ b/tests/test_examples/test_generate_and_add_a_missing_icon_to_the_map.py
@@ -1,0 +1,73 @@
+from maplibreum import Map
+from maplibreum.layers import SymbolLayer
+from maplibreum.sources import GeoJSONSource
+
+
+MISSING_ICON_JS = """
+map.on('styleimagemissing', (e) => {
+    const id = e.id;
+    const prefix = 'square-rgb-';
+    if (!id.startsWith(prefix)) {
+        return;
+    }
+    const rgb = id.replace(prefix, '').split(',').map(Number);
+    const width = 64;
+    const bytesPerPixel = 4;
+    const data = new Uint8Array(width * width * bytesPerPixel);
+    for (let x = 0; x < width; x++) {
+        for (let y = 0; y < width; y++) {
+            const offset = (y * width + x) * bytesPerPixel;
+            data[offset + 0] = rgb[0];
+            data[offset + 1] = rgb[1];
+            data[offset + 2] = rgb[2];
+            data[offset + 3] = 255;
+        }
+    }
+    map.addImage(id, { width, height: width, data });
+});
+"""
+
+
+def test_generate_and_add_a_missing_icon_to_the_map():
+    m = Map(map_style="https://demotiles.maplibre.org/style.json")
+
+    points = GeoJSONSource(
+        data={
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "properties": {"color": "255,0,0"},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [50, 0]},
+                    "properties": {"color": "255,209,28"},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [-50, 0]},
+                    "properties": {"color": "242,127,32"},
+                },
+            ],
+        }
+    )
+
+    layer = SymbolLayer(
+        id="points",
+        source="points",
+        layout={"icon-image": ["concat", "square-rgb-", ["get", "color"]]},
+    )
+
+    m.add_source("points", points)
+    m.add_layer(layer)
+    m.add_on_load_js(MISSING_ICON_JS)
+
+    html = m.render()
+
+    assert "styleimagemissing" in html
+    assert "map.addImage(id" in html
+    assert "square-rgb-" in html
+    assert any(source["name"] == "points" for source in m.sources)
+    assert any(layer_info["definition"]["layout"]["icon-image"][0] == "concat" for layer_info in m.layers)

--- a/tests/test_examples/test_geocode_with_nominatim.py
+++ b/tests/test_examples/test_geocode_with_nominatim.py
@@ -1,0 +1,61 @@
+from maplibreum import Map
+
+
+GEOCODER_SCRIPT = "https://unpkg.com/@maplibre/maplibre-gl-geocoder@1.5.0/dist/maplibre-gl-geocoder.min.js"
+
+
+GEOCODER_JS = """
+const nominatimResponse = {
+    features: [
+        {
+            bbox: [-87.627815, 41.867576, -87.615211, 41.87221],
+            properties: { display_name: 'Museum Campus, Chicago, Illinois, United States' },
+        },
+    ],
+};
+const geocoderApi = {
+    forwardGeocode: async (config) => {
+        const query = config.query;
+        console.log('Mock forwardGeocode query', query);
+        const featureCollection = nominatimResponse.features.map((feature) => {
+            const center = [
+                feature.bbox[0] + (feature.bbox[2] - feature.bbox[0]) / 2,
+                feature.bbox[1] + (feature.bbox[3] - feature.bbox[1]) / 2,
+            ];
+            return {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: center },
+                place_name: feature.properties.display_name,
+                properties: feature.properties,
+                text: feature.properties.display_name,
+                place_type: ['place'],
+                center,
+            };
+        });
+        return { features: featureCollection };
+    },
+};
+map.addControl(new MaplibreGeocoder(geocoderApi, { maplibregl }));
+"""
+
+
+def test_geocode_with_nominatim():
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-87.61694, 41.86625],
+        zoom=15.99,
+        pitch=40,
+        bearing=20,
+        map_options={"canvasContextAttributes": {"antialias": True}},
+    )
+
+    m.add_external_script(GEOCODER_SCRIPT)
+    m.add_on_load_js(GEOCODER_JS)
+
+    html = m.render()
+
+    assert GEOCODER_SCRIPT in html
+    assert "MaplibreGeocoder" in html
+    assert "forwardGeocode" in html
+    assert "Mock forwardGeocode query" in html
+    assert '"canvasContextAttributes":{"antialias":true}' in html.replace("\n", "").replace(" ", "")

--- a/tests/test_examples/test_pmtiles_source_and_protocol.py
+++ b/tests/test_examples/test_pmtiles_source_and_protocol.py
@@ -1,0 +1,68 @@
+from maplibreum import Map
+
+PMTILES_ARCHIVE = "https://pmtiles.io/protomaps(vector)ODbL_firenze.pmtiles"
+PMTILES_SCRIPT = "https://unpkg.com/pmtiles@3.2.0/dist/pmtiles.js"
+
+
+PROTOCOL_JS = """
+const protocol = new pmtiles.Protocol();
+maplibregl.addProtocol('pmtiles', protocol.tile);
+const archive = new pmtiles.PMTiles('https://pmtiles.io/protomaps(vector)ODbL_firenze.pmtiles');
+protocol.add(archive);
+"""
+
+
+STYLE = {
+    "version": 8,
+    "sources": {
+        "example_source": {
+            "type": "vector",
+            "url": "pmtiles://" + PMTILES_ARCHIVE,
+            "attribution": '© <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>',
+        }
+    },
+    "layers": [
+        {
+            "id": "buildings",
+            "type": "fill",
+            "source": "example_source",
+            "source-layer": "landuse",
+            "paint": {"fill-color": "steelblue"},
+        },
+        {
+            "id": "roads",
+            "type": "line",
+            "source": "example_source",
+            "source-layer": "roads",
+            "paint": {"line-color": "black"},
+        },
+        {
+            "id": "mask",
+            "type": "fill",
+            "source": "example_source",
+            "source-layer": "mask",
+            "paint": {"fill-color": "white"},
+        },
+    ],
+}
+
+
+def test_pmtiles_source_and_protocol():
+    m = Map(
+        map_style=STYLE,
+        center=[11.255, 43.7696],
+        zoom=12,
+    )
+
+    m.add_external_script(PMTILES_SCRIPT)
+    m.add_on_load_js(PROTOCOL_JS)
+
+    html = m.render()
+
+    assert PMTILES_SCRIPT in html
+    assert "pmtiles.Protocol" in html
+    assert "maplibregl.addProtocol('pmtiles'" in html
+    assert f"pmtiles://{PMTILES_ARCHIVE}" in html
+    assert '"example_source"' in html
+    assert '"source-layer": "landuse"' in html.replace("\n", "")
+    assert '"source-layer": "roads"' in html.replace("\n", "")

--- a/tests/test_examples/test_toggle_deckgl_layer.py
+++ b/tests/test_examples/test_toggle_deckgl_layer.py
@@ -1,0 +1,102 @@
+from maplibreum import Map
+
+
+DECKGL_SCRIPT = "https://unpkg.com/deck.gl@8.9.33/dist.min.js"
+
+
+TOGGLE_JS = """
+const apiUrl = 'https://maps.clockworkmicro.com/streets/v1/style?x-api-key=';
+const apiKey = 'Dr4eW3s233rRkk8I_public';
+let overlay;
+const sampleData = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            properties: { name: 'Jardins du Trocadéro', district: 16 },
+            geometry: { type: 'Point', coordinates: [2.289207, 48.861561] },
+        },
+        {
+            type: 'Feature',
+            properties: { name: 'Jardin des Plantes', district: 5 },
+            geometry: { type: 'Point', coordinates: [2.359823, 48.843995] },
+        },
+        {
+            type: 'Feature',
+            properties: { name: 'Jardins das Tulherias', district: 1 },
+            geometry: { type: 'Point', coordinates: [2.327092, 48.863608] },
+        },
+        {
+            type: 'Feature',
+            properties: { name: 'Parc de Bercy', district: 12 },
+            geometry: { type: 'Point', coordinates: [2.382094, 48.835962] },
+        },
+        {
+            type: 'Feature',
+            properties: { name: 'Jardin du Luxemburg', district: 6 },
+            geometry: { type: 'Point', coordinates: [2.336975, 48.846421] },
+        },
+    ],
+};
+function initialiseOverlay() {
+    const layer = new deck.ScatterplotLayer({
+        id: 'scatterplot-layer',
+        data: sampleData.features,
+        pickable: true,
+        opacity: 0.8,
+        stroked: true,
+        filled: true,
+        radiusScale: 6,
+        radiusMinPixels: 20,
+        radiusMaxPixels: 100,
+        lineWidthMinPixels: 5,
+        getPosition: (d) => d.geometry.coordinates,
+        getFillColor: () => [49, 130, 206],
+        getLineColor: () => [175, 0, 32],
+        onClick: (info) => {
+            const { coordinate, object } = info;
+            const description = `<div><p><strong>Name: </strong>${object.properties.name}</p><p><strong>District: </strong>${object.properties.district}</p></div>`;
+            new maplibregl.Popup().setLngLat(coordinate).setHTML(description).addTo(map);
+        },
+    });
+    overlay = new deck.MapboxOverlay({ layers: [layer] });
+    map.addControl(overlay);
+}
+map.on('load', () => {
+    initialiseOverlay();
+    const toggleButton = document.createElement('button');
+    toggleButton.id = 'toggle-button';
+    toggleButton.textContent = 'Hide';
+    toggleButton.addEventListener('click', () => {
+        if (toggleButton.textContent === 'Hide') {
+            map.removeControl(overlay);
+            toggleButton.textContent = 'Show';
+        } else {
+            initialiseOverlay();
+            toggleButton.textContent = 'Hide';
+        }
+    });
+    map.getContainer().appendChild(toggleButton);
+});
+"""
+
+
+def test_toggle_deckgl_layer():
+    m = Map(
+        map_style="https://maps.clockworkmicro.com/streets/v1/style?x-api-key=Dr4eW3s233rRkk8I_public",
+        center=[2.345885, 48.860412],
+        zoom=12,
+    )
+
+    m.add_external_script(DECKGL_SCRIPT)
+    m.add_on_load_js(TOGGLE_JS)
+
+    html = m.render()
+
+    assert DECKGL_SCRIPT in html
+    assert "toggleButton" in html
+    assert "map.removeControl(overlay)" in html
+    assert "initialiseOverlay" in html
+    assert '"style": "https://maps.clockworkmicro.com/streets/v1/style?x-api-key=Dr4eW3s233rRkk8I_public"' in html.replace("\n", "")
+    assert '"center": [2.345885, 48.860412]' in html
+    assert '"zoom": 12' in html

--- a/tests/test_examples/test_update_a_feature_in_realtime.py
+++ b/tests/test_examples/test_update_a_feature_in_realtime.py
@@ -1,0 +1,77 @@
+from maplibreum import Map
+from maplibreum.layers import LineLayer
+from maplibreum.sources import GeoJSONSource
+
+
+D3_SCRIPT = "https://d3js.org/d3.v3.min.js"
+
+
+TRACE_TEMPLATE = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {"type": "LineString", "coordinates": []},
+        }
+    ],
+}
+
+
+REALTIME_JS = """
+map.on('load', () => {
+    d3.json('https://maplibre.org/maplibre-gl-js/docs/assets/hike.geojson', (err, data) => {
+        if (err) {
+            throw err;
+        }
+        const coordinates = data.features[0].geometry.coordinates;
+        data.features[0].geometry.coordinates = [coordinates[0]];
+        map.getSource('trace').setData(data);
+        map.jumpTo({ center: coordinates[0], zoom: 14 });
+        map.setPitch(30);
+        let i = 0;
+        const timer = window.setInterval(() => {
+            if (i < coordinates.length) {
+                data.features[0].geometry.coordinates.push(coordinates[i]);
+                map.getSource('trace').setData(data);
+                map.panTo(coordinates[i]);
+                i++;
+            } else {
+                window.clearInterval(timer);
+            }
+        }, 10);
+    });
+});
+"""
+
+
+def test_update_a_feature_in_realtime():
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        zoom=0,
+    )
+
+    m.add_source("trace", GeoJSONSource(data=TRACE_TEMPLATE))
+    m.add_layer(
+        LineLayer(
+            id="trace",
+            source="trace",
+            paint={
+                "line-color": "yellow",
+                "line-opacity": 0.75,
+                "line-width": 5,
+            },
+        )
+    )
+    m.add_external_script(D3_SCRIPT)
+    m.add_on_load_js(REALTIME_JS)
+
+    html = m.render()
+
+    assert D3_SCRIPT in html
+    assert "d3.json" in html
+    assert any(source["name"] == "trace" for source in m.sources)
+    assert any(layer["definition"]["id"] == "trace" for layer in m.layers)
+    assert "map.getSource('trace').setData" in html
+    assert "window.setInterval" in html
+    assert "map.getSource('trace').setData(data);" in html

--- a/tests/test_examples/test_use_a_fallback_image.py
+++ b/tests/test_examples/test_use_a_fallback_image.py
@@ -1,0 +1,60 @@
+from maplibreum import Map
+from maplibreum.layers import SymbolLayer
+from maplibreum.sources import GeoJSONSource
+
+
+def test_use_a_fallback_image():
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-77, 38.75],
+        zoom=5,
+    )
+
+    points = GeoJSONSource(
+        data={
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [-77.03238901390978, 38.913188059745586]},
+                    "properties": {"title": "Washington DC", "icon": "monument"},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [-79.9959, 40.4406]},
+                    "properties": {"title": "Pittsburgh", "icon": "bridges"},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [-76.2859, 36.8508]},
+                    "properties": {"title": "Norfolk", "icon": "harbor"},
+                },
+            ],
+        }
+    )
+
+    layer = SymbolLayer(
+        id="points",
+        source="points",
+        layout={
+            "icon-image": [
+                "coalesce",
+                ["image", ["concat", ["get", "icon"], "_11"]],
+                ["image", "marker_11"],
+            ],
+            "text-field": ["get", "title"],
+            "text-font": ["Noto Sans Regular"],
+            "text-offset": [0, 0.6],
+            "text-anchor": "top",
+        },
+    )
+
+    m.add_source("points", points)
+    m.add_layer(layer)
+
+    html = m.render()
+
+    assert any(source["name"] == "points" for source in m.sources)
+    assert any(layer_info["definition"]["layout"]["icon-image"][0] == "coalesce" for layer_info in m.layers)
+    assert "\"coalesce\"" in html
+    assert "marker_11" in html

--- a/tests/test_examples/test_use_addprotocol_to_transform_feature_properties.py
+++ b/tests/test_examples/test_use_addprotocol_to_transform_feature_properties.py
@@ -1,0 +1,64 @@
+from maplibreum import Map
+
+
+TRANSFORM_JS = """
+(async () => {
+    const protocolName = 'reverse';
+    const [{ default: Protobuf }, { VectorTile }, { default: tileToProtobuf }] = await Promise.all([
+        import('https://unpkg.com/pbf@4.0.1/dist/pbf.min.js'),
+        import('https://esm.run/@mapbox/vector-tile@2.0.3/index.js'),
+        import('https://esm.run/vt-pbf@3.1.3/index.js'),
+    ]);
+    maplibregl.addProtocol(protocolName, async (request) => {
+        const url = request.url.replace(protocolName + '://', '');
+        const response = await fetch(url);
+        const data = await response.arrayBuffer();
+        const tile = new VectorTile(new Protobuf(data));
+        const layers = Object.fromEntries(
+            Object.entries(tile.layers).map(([layerId, layer]) => [
+                layerId,
+                {
+                    ...layer,
+                    feature: (index) => {
+                        const feature = layer.feature(index);
+                        if (feature.properties && typeof feature.properties['NAME'] === 'string') {
+                            feature.properties['NAME'] = feature.properties['NAME'].split('').reverse().join('');
+                        }
+                        if (feature.properties && typeof feature.properties['ABBREV'] === 'string') {
+                            feature.properties['ABBREV'] = feature.properties['ABBREV'].split('').reverse().join('');
+                        }
+                        return feature;
+                    },
+                },
+            ])
+        );
+        const encoded = tileToProtobuf({ layers });
+        return { data: encoded.buffer };
+    });
+    map.setTransformRequest((url, resourceType) => {
+        if (url.startsWith('https://demotiles.maplibre.org/tiles/') && resourceType === 'Tile') {
+            return { url: protocolName + '://' + url };
+        }
+        return undefined;
+    });
+})();
+"""
+
+
+def test_use_addprotocol_to_transform_feature_properties():
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[8, 47],
+        zoom=5,
+        map_options={"hash": "map"},
+    )
+
+    m.add_on_load_js(TRANSFORM_JS)
+
+    html = m.render()
+
+    assert "maplibregl.addProtocol(protocolName" in html
+    assert "tileToProtobuf" in html
+    assert "map.setTransformRequest" in html
+    assert "split('').reverse().join('')" in html
+    assert '"hash": "map"' in html.replace("\n", "")

--- a/tests/test_examples/test_use_locally_generated_ideographs.py
+++ b/tests/test_examples/test_use_locally_generated_ideographs.py
@@ -1,0 +1,18 @@
+from maplibreum import Map
+
+
+def test_use_locally_generated_ideographs():
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[120.3049, 31.4751],
+        zoom=12,
+        map_options={"localIdeographFontFamily": '"Apple LiSung", serif'},
+    )
+
+    assert m.additional_map_options["localIdeographFontFamily"] == '"Apple LiSung", serif'
+
+    html = m.render()
+
+    assert 'localIdeographFontFamily' in html
+    assert '"center": [120.3049, 31.4751]' in html
+    assert '"zoom": 12' in html

--- a/tests/test_examples/test_view_local_geojson.py
+++ b/tests/test_examples/test_view_local_geojson.py
@@ -1,0 +1,133 @@
+from maplibreum import Map
+from maplibreum.layers import FillLayer
+from maplibreum.sources import GeoJSONSource
+
+
+EMPTY_FEATURE_COLLECTION = {"type": "FeatureCollection", "features": []}
+
+
+UPLOAD_JS = """
+const fileInput = document.createElement('input');
+fileInput.type = 'file';
+fileInput.accept = 'application/geo+json,application/vnd.geo+json,.geojson';
+fileInput.id = 'uploaded-geojson-file';
+fileInput.style.position = 'absolute';
+fileInput.style.top = '0';
+fileInput.style.left = '0';
+const container = map.getContainer();
+container.appendChild(fileInput);
+fileInput.addEventListener('change', (evt) => {
+    const file = evt.target.files[0];
+    if (!file) {
+        return;
+    }
+    const reader = new FileReader();
+    reader.onload = (event) => {
+        const geoJSONcontent = JSON.parse(event.target.result);
+        map.getSource('uploaded-source').setData(geoJSONcontent);
+    };
+    reader.readAsText(file, 'UTF-8');
+});
+"""
+
+
+EXPERIMENTAL_JS = """
+const button = document.createElement('button');
+button.id = 'viewbutton';
+button.textContent = 'View local GeoJSON file';
+button.style.position = 'absolute';
+button.style.top = '0';
+button.style.left = '0';
+map.getContainer().appendChild(button);
+async function buttonClickHandler() {
+    const [fileHandle] = await window.showOpenFilePicker({
+        multiple: false,
+        types: [
+            {
+                description: 'GeoJSON',
+                accept: { 'application/geo+json': ['.geojson'] },
+            },
+        ],
+        startIn: 'downloads',
+    });
+    const file = await fileHandle.getFile();
+    const contents = await file.text();
+    map.getSource('uploaded-source').setData(JSON.parse(contents));
+}
+if ('showOpenFilePicker' in window) {
+    button.addEventListener('click', buttonClickHandler);
+} else {
+    button.textContent = 'Your browser does not support File System Access API';
+}
+"""
+
+
+def test_view_local_geojson():
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-8.3226655, 53.7654751],
+        zoom=8,
+    )
+
+    m.add_source(
+        "uploaded-source",
+        GeoJSONSource(data=EMPTY_FEATURE_COLLECTION),
+    )
+    m.add_layer(
+        FillLayer(
+            id="uploaded-polygons",
+            source="uploaded-source",
+            paint={
+                "fill-color": "#888888",
+                "fill-outline-color": "red",
+                "fill-opacity": 0.4,
+            },
+            filter=["==", "$type", "Polygon"],
+        )
+    )
+    m.add_on_load_js(UPLOAD_JS)
+
+    html = m.render()
+
+    assert "uploaded-geojson-file" in html
+    assert "FileReader" in html
+    assert any(source["name"] == "uploaded-source" for source in m.sources)
+    assert any(layer["definition"]["id"] == "uploaded-polygons" for layer in m.layers)
+    assert "map.getSource('uploaded-source').setData" in html
+    assert '["==","$type","Polygon"]' in html.replace(" ", "").replace("\n", "")
+
+
+def test_view_local_geojson_experimental():
+    m = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-8.3226655, 53.7654751],
+        zoom=8,
+    )
+
+    m.add_source(
+        "uploaded-source",
+        GeoJSONSource(data=EMPTY_FEATURE_COLLECTION),
+    )
+    m.add_layer(
+        FillLayer(
+            id="uploaded-polygons",
+            source="uploaded-source",
+            paint={
+                "fill-color": "#888888",
+                "fill-outline-color": "red",
+                "fill-opacity": 0.4,
+            },
+            filter=["==", "$type", "Polygon"],
+        )
+    )
+    m.add_on_load_js(EXPERIMENTAL_JS)
+
+    html = m.render()
+
+    assert "showOpenFilePicker" in html
+    assert "buttonClickHandler" in html
+    assert any(source["name"] == "uploaded-source" for source in m.sources)
+    assert any(layer["definition"]["id"] == "uploaded-polygons" for layer in m.layers)
+    assert "map.getSource('uploaded-source').setData" in html
+    assert '["==","$type","Polygon"]' in html.replace(" ", "").replace("\n", "")
+    assert "Your browser does not support File System Access API" in html


### PR DESCRIPTION
## Summary
- register the deck.gl REST overlay example's navigation control through the Map API instead of inlined JavaScript
- preconfigure GeoJSON sources and fill layers for the local upload workflows so the injected handlers only update existing data
- seed the realtime trace example with Map-managed sources and layers while keeping the JavaScript focused on streaming updates

## Testing
- pytest tests/test_examples -k "deckgl or pmtiles or missing_icon or nominatim or realtime or fallback_image or addprotocol or ideographs or view_local_geojson"


------
https://chatgpt.com/codex/tasks/task_b_68d76d8f1750832fa4ff7a681f2da20b