### PR TITLE
feat: Implemented `check-if-webgl-is-supported` example

### DIFF
--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -327,8 +327,8 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/check-if-webgl-is-supported/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/check-if-webgl-is-supported.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_check_if_webgl_is_supported.py"
   },
   "cooperative-gestures": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/cooperative-gestures/",

--- a/tests/test_examples/test_check_if_webgl_is_supported.py
+++ b/tests/test_examples/test_check_if_webgl_is_supported.py
@@ -1,0 +1,53 @@
+"""Test for check-if-webgl-is-supported MapLibre example."""
+from maplibreum.core import Map
+
+
+def test_check_if_webgl_is_supported():
+    """Test recreating the 'check-if-webgl-is-supported' MapLibre example."""
+    # JavaScript to check for WebGL support and conditionally initialize the map
+    js_code = """
+    const originalMap = maplibregl.Map;
+    maplibregl.Map = function (options) {
+        if (isWebglSupported()) {
+            return new originalMap(options);
+        } else {
+            alert('Your browser does not support WebGL');
+            return null;
+        }
+    };
+
+    function isWebglSupported() {
+        if (window.WebGLRenderingContext) {
+            const canvas = document.createElement('canvas');
+            try {
+                const context = canvas.getContext('webgl2') || canvas.getContext('webgl');
+                if (context && typeof context.getParameter == 'function') {
+                    return true;
+                }
+            } catch (e) {
+                // WebGL is supported, but disabled
+            }
+            return false;
+        }
+        // WebGL not supported
+        return false;
+    }
+    """
+
+    # Create a map instance and inject the custom JavaScript
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[-74.5, 40],
+        zoom=2,
+        extra_js=js_code,
+    )
+
+    # Render the HTML
+    html = m.render()
+
+    # Verify that the custom JavaScript is included in the rendered HTML
+    assert "const originalMap = maplibregl.Map;" in html
+    assert "function isWebglSupported()" in html
+    assert "alert('Your browser does not support WebGL');" in html
+    assert "new originalMap(options);" in html
+    assert "https://demotiles.maplibre.org/style.json" in html


### PR DESCRIPTION
This commit introduces a new test file, `tests/test_examples/test_check_if_webgl_is_supported.py`, to replicate the official MapLibre GL JS example for checking WebGL support.

The implementation uses the `extra_js` parameter to inject a script that conditionally initializes the map. It overrides the `maplibregl.Map` constructor to first check for WebGL support. If WebGL is available, the original constructor is called; otherwise, an alert is shown.

The `status.json` file has been updated to reflect the completion of this example, marking `task_status` as `true` and adding the path to the new test script.