### PR TITLE
feat: Add extrude-polygons-for-3d-indoor-mapping example

### DIFF
--- a/misc/maplibre_examples/README.md
+++ b/misc/maplibre_examples/README.md
@@ -158,12 +158,13 @@ When converting JavaScript examples to Python:
 
 ### Coverage Summary
 
-**Current Coverage:** 47/123 examples completed
+**Current Coverage:** 48/123 examples completed
 
 - ✅ Ported `add-a-3d-model-to-globe-using-threejs` leveraging the new
   `Map.add_external_script` helper to load three.js dependencies and attach a
   custom layer via `add_on_load_js`.
 - ✅ Implemented `display-buildings-in-3d` by dynamically inserting a `fill-extrusion` layer before the first symbol layer, ensuring labels render correctly on top of 3D buildings.
+- ✅ Added `extrude-polygons-for-3d-indoor-mapping` to showcase 3D indoor mapping using the `fill-extrusion-height` paint property.
 
 ### Edge-case Validation
 
@@ -190,5 +191,5 @@ While the gallery coverage is exhaustive, a few MapLibre capabilities still requ
 
 We're tracking towards the **123/123 coverage** milestone—complete feature
 parity with the official MapLibre GL JS gallery while preserving a templated,
-reproducible HTML/JS pipeline. Current parity stands at **47/123** with the
+reproducible HTML/JS pipeline. Current parity stands at **48/123** with the
 three.js globe example now automated.

--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -565,8 +565,8 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/extrude-polygons-for-3d-indoor-mapping/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/extrude-polygons-for-3d-indoor-mapping.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_extrude_polygons_for_3d_indoor_mapping.py"
   },
   "filter-layer-symbols-using-global-state": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/filter-layer-symbols-using-global-state/",

--- a/tests/test_examples/test_extrude_polygons_for_3d_indoor_mapping.py
+++ b/tests/test_examples/test_extrude_polygons_for_3d_indoor_mapping.py
@@ -1,0 +1,85 @@
+"""Test for extrude-polygons-for-3d-indoor-mapping example."""
+from maplibreum import Map
+from maplibreum.layers import FillExtrusionLayer
+from maplibreum.sources import GeoJSONSource
+
+URL = "https://maplibre.org/maplibre-gl-js/docs/assets/indoor-3d-map.geojson"
+
+
+def test_extrude_polygons_for_3d_indoor_mapping():
+    """Test recreating the 'extrude-polygons-for-3d-indoor-mapping' MapLibre example."""
+    map_options = dict(
+        center=[-87.61694, 41.86625],
+        zoom=15.99,
+        pitch=40,
+        bearing=20,
+    )
+
+    style = {
+        "id": "raster",
+        "version": 8,
+        "name": "Raster tiles",
+        "center": [0, 0],
+        "zoom": 0,
+        "sources": {
+            "raster-tiles": {
+                "type": "raster",
+                "tiles": ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+                "tileSize": 256,
+                "minzoom": 0,
+                "maxzoom": 19,
+            }
+        },
+        "layers": [
+            {"id": "background", "type": "background", "paint": {"background-color": "#e0dfdf"}},
+            {"id": "simple-tiles", "type": "raster", "source": "raster-tiles"},
+        ],
+    }
+
+    m = Map(map_style=style, **map_options)
+
+    source = GeoJSONSource(data=URL)
+    m.add_source("floorplan", source)
+
+    layer = FillExtrusionLayer(
+        id="room-extrusion",
+        source="floorplan",
+        paint={
+            "fill-extrusion-color": ["get", "color"],
+            "fill-extrusion-height": ["get", "height"],
+            "fill-extrusion-base": ["get", "base_height"],
+            "fill-extrusion-opacity": 0.5,
+        },
+    )
+    m.add_layer(layer)
+
+    # Verify map properties
+    assert m.center == [-87.61694, 41.86625]
+    assert m.zoom == 15.99
+    assert m.pitch == 40
+    assert m.bearing == 20
+
+    # Verify source
+    assert len(m.sources) == 1
+    floorplan_source = m.sources[0]
+    assert floorplan_source["name"] == "floorplan"
+    assert floorplan_source["definition"]["type"] == "geojson"
+    assert floorplan_source["definition"]["data"] == URL
+
+    # Verify layer
+    assert len(m.layers) == 1
+    extrusion_layer = m.layers[0]
+    assert extrusion_layer["definition"]["id"] == "room-extrusion"
+    assert extrusion_layer["definition"]["type"] == "fill-extrusion"
+    assert extrusion_layer["definition"]["source"] == "floorplan"
+    paint = extrusion_layer["definition"]["paint"]
+    assert paint["fill-extrusion-color"] == ["get", "color"]
+    assert paint["fill-extrusion-height"] == ["get", "height"]
+    assert paint["fill-extrusion-base"] == ["get", "base_height"]
+    assert paint["fill-extrusion-opacity"] == 0.5
+
+    # Render and verify HTML
+    html = m.render()
+    assert "room-extrusion" in html
+    assert "fill-extrusion" in html
+    assert "indoor-3d-map.geojson" in html


### PR DESCRIPTION
This commit adds a new example to the MapLibre examples testing suite, `extrude-polygons-for-3d-indoor-mapping`.

The new test file, `tests/test_examples/test_extrude_polygons_for_3d_indoor_mapping.py`, implements the example by creating a map with a `fill-extrusion` layer, using a GeoJSON source to display 3D indoor polygons.

The `misc/maplibre_examples/status.json` and `misc/maplibre_examples/README.md` files have been updated to reflect the addition of this new example, increasing the total coverage count.