### PR TITLE
feat: Add set-center-point-above-ground example

### DIFF
--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -254,6 +254,8 @@ class Map:
         zoom=2,
         pitch=None,
         bearing=None,
+        elevation=None,
+        center_clamped_to_ground=None,
         width="100%",
         height="500px",
         controls=None,
@@ -281,6 +283,8 @@ class Map:
         self.zoom = zoom
         self.pitch = pitch
         self.bearing = bearing
+        self.elevation = elevation
+        self.center_clamped_to_ground = center_clamped_to_ground
         self.width = width
         self.height = height
         self.controls = controls if controls is not None else []
@@ -1563,6 +1567,10 @@ class Map:
             map_options["pitch"] = self.pitch
         if self.bearing is not None:
             map_options["bearing"] = self.bearing
+        if self.elevation is not None:
+            map_options["elevation"] = self.elevation
+        if self.center_clamped_to_ground is not None:
+            map_options["centerClampedToGround"] = self.center_clamped_to_ground
         if self.additional_map_options:
             map_options.update(self.additional_map_options)
 

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -169,7 +169,7 @@
         function initializeMap() {
             try {
         // Initialize map
-        var map = new maplibregl.Map({{ map_options | tojson }});
+        var map = new maplibregl.Map({{ map_options | tojson | safe }});
         window.maplibreumMaps = window.maplibreumMaps || {};
         window.maplibreumMaps["{{ map_id }}"] = map;
         window.maplibreumMapsLoaded = window.maplibreumMapsLoaded || {};

--- a/misc/maplibre_examples/README.md
+++ b/misc/maplibre_examples/README.md
@@ -165,6 +165,7 @@ When converting JavaScript examples to Python:
   custom layer via `add_on_load_js`.
 - ✅ Implemented `display-buildings-in-3d` by dynamically inserting a `fill-extrusion` layer before the first symbol layer, ensuring labels render correctly on top of 3D buildings.
 - ✅ Added `extrude-polygons-for-3d-indoor-mapping` to showcase 3D indoor mapping using the `fill-extrusion-height` paint property.
+- ✅ Implemented `set-center-point-above-ground` by adding `elevation` and `centerClampedToGround` properties to the `Map` constructor, allowing for camera positioning relative to the terrain.
 
 ### Edge-case Validation
 

--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -726,8 +726,8 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/set-center-point-above-ground/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/set-center-point-above-ground.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_set_center_point_above_ground.py"
   },
   "set-pitch-and-bearing": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/set-pitch-and-bearing/",

--- a/tests/test_examples/test_set_center_point_above_ground.py
+++ b/tests/test_examples/test_set_center_point_above_ground.py
@@ -1,0 +1,69 @@
+from maplibreum import Map
+from maplibreum.expressions import get, interpolate
+from maplibreum.layers import FillExtrusionLayer
+
+MAP_STYLE = {
+    "version": 8,
+    "sources": {
+        "openfreemap": {
+            "url": "https://tiles.openfreemap.org/planet",
+            "type": "vector",
+        }
+    },
+    "layers": [],
+}
+
+
+def test_set_center_point_above_ground():
+    m = Map(
+        map_style=MAP_STYLE,
+        center=[-74.01318, 40.713],
+        zoom=15.5,
+        pitch=85,
+        bearing=-17.6,
+        center_clamped_to_ground=False,
+        elevation=541,
+        map_options={"maxPitch": 105, "minZoom": 13},
+    )
+
+    buildings_layer = FillExtrusionLayer(
+        id="3d-buildings",
+        source="openfreemap",
+        source_layer="building",
+        min_zoom=13,
+        filter=["!=", ["get", "hide_3d"], True],
+        paint={
+            "fill-extrusion-color": [
+                "interpolate",
+                ["linear"],
+                ["get", "render_height"],
+                0,
+                "lightgray",
+                200,
+                "royalblue",
+                400,
+                "lightblue",
+            ],
+            "fill-extrusion-height": [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                13,
+                0,
+                14,
+                ["get", "render_height"],
+            ],
+            "fill-extrusion-base": [
+                "case",
+                [">=", ["get", "zoom"], 16],
+                ["get", "render_min_height"],
+                0,
+            ],
+        },
+    )
+
+    m.add_layer(buildings_layer)
+
+    html_data = m.render()
+    assert '"centerClampedToGround": false' in html_data
+    assert '"elevation": 541' in html_data


### PR DESCRIPTION
This commit implements the "set-center-point-above-ground" example from the official MapLibre GL JS documentation.

It adds support for the `elevation` and `centerClampedToGround` properties in the `maplibreum.Map` class.

A new test case is added to `tests/test_examples` to validate the implementation.

The `status.json` and `README.md` files have been updated to reflect the new example's completion.