### PR TITLE
feat: Implement show-polygon-information-on-click example

### DIFF
--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -740,8 +740,8 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/show-polygon-information-on-click/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/show-polygon-information-on-click.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_show_polygon_information_on_click.py"
   },
   "sky-fog-terrain": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/sky-fog-terrain/",

--- a/tests/test_examples/test_show_polygon_information_on_click.py
+++ b/tests/test_examples/test_show_polygon_information_on_click.py
@@ -1,0 +1,66 @@
+import json
+from maplibreum import Map
+from maplibreum.sources import GeoJSONSource
+
+def test_show_polygon_information_on_click():
+    """
+    Test the 'show-polygon-information-on-click' example.
+    """
+    # Create a map
+    map_ = Map(
+        center=[-100.04, 38.907],
+        zoom=3,
+        map_style="https://demotiles.maplibre.org/style.json",
+    )
+
+    # Add a GeoJSON source for the states
+    map_.add_source(
+        "states",
+        GeoJSONSource(data="https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_admin_1_states_provinces_shp.geojson")
+    )
+
+    # Add a layer showing the state polygons
+    map_.add_layer(
+        {
+            "id": "states-layer",
+            "type": "fill",
+            "source": "states",
+            "paint": {
+                "fill-color": "rgba(200, 100, 240, 0.4)",
+                "fill-outline-color": "rgba(200, 100, 240, 1)",
+            },
+        }
+    )
+
+    # Add a click event listener to the states layer to show a popup
+    map_.add_event_listener(
+        "click",
+        layer_id="states-layer",
+        js="""
+        new maplibregl.Popup()
+            .setLngLat(e.lngLat)
+            .setHTML(e.features[0].properties.name)
+            .addTo(map);
+        """,
+    )
+
+    # Add mouseenter and mouseleave event listeners to change the cursor
+    map_.add_event_listener(
+        "mouseenter",
+        layer_id="states-layer",
+        js="map.getCanvas().style.cursor = 'pointer';",
+    )
+    map_.add_event_listener(
+        "mouseleave",
+        layer_id="states-layer",
+        js="map.getCanvas().style.cursor = '';",
+    )
+
+    # Get the map's HTML representation
+    html = map_.render()
+
+    # Verify that the necessary JavaScript snippets are in the HTML
+    assert "new maplibregl.Popup()" in html
+    assert "e.features[0].properties.name" in html
+    assert "map.getCanvas().style.cursor = 'pointer';" in html
+    assert "map.getCanvas().style.cursor = '';" in html


### PR DESCRIPTION
This commit adds a new test file to implement the `show-polygon-information-on-click` example from the MapLibre GL JS documentation.

The implementation includes:
- A new test file `tests/test_examples/test_show_polygon_information_on_click.py`.
- A test function that creates a map and adds a GeoJSON source with state polygons.
- Event listeners for `click`, `mouseenter`, and `mouseleave` to display a popup and change the cursor.
- An update to `misc/maplibre_examples/status.json` to mark the example as complete.