### PR TITLE
feat: Add variable-label-placement example and fix environment

### DIFF
--- a/misc/maplibre_examples/README.md
+++ b/misc/maplibre_examples/README.md
@@ -158,7 +158,7 @@ When converting JavaScript examples to Python:
 
 ### Coverage Summary
 
-**Current Coverage:** 48/123 examples completed
+**Current Coverage:** 49/123 examples completed
 
 - ✅ Ported `add-a-3d-model-to-globe-using-threejs` leveraging the new
   `Map.add_external_script` helper to load three.js dependencies and attach a
@@ -166,6 +166,7 @@ When converting JavaScript examples to Python:
 - ✅ Implemented `display-buildings-in-3d` by dynamically inserting a `fill-extrusion` layer before the first symbol layer, ensuring labels render correctly on top of 3D buildings.
 - ✅ Added `extrude-polygons-for-3d-indoor-mapping` to showcase 3D indoor mapping using the `fill-extrusion-height` paint property.
 - ✅ Implemented `set-center-point-above-ground` by adding `elevation` and `centerClampedToGround` properties to the `Map` constructor, allowing for camera positioning relative to the terrain.
+- ✅ Added `variable-label-placement` to demonstrate dynamic label repositioning using the `text-variable-anchor` and `text-radial-offset` layout properties, preventing label overlap during map interactions.
 
 ### Edge-case Validation
 
@@ -192,5 +193,5 @@ While the gallery coverage is exhaustive, a few MapLibre capabilities still requ
 
 We're tracking towards the **123/123 coverage** milestone—complete feature
 parity with the official MapLibre GL JS gallery while preserving a templated,
-reproducible HTML/JS pipeline. Current parity stands at **48/123** with the
+reproducible HTML/JS pipeline. Current parity stands at **49/123** with the
 three.js globe example now automated.

--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -817,8 +817,8 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/variable-label-placement.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_variable_label_placement.py"
   },
   "variable-label-placement-with-offset": {
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/variable-label-placement-with-offset/",

--- a/tests/test_examples/test_variable_label_placement.py
+++ b/tests/test_examples/test_variable_label_placement.py
@@ -1,0 +1,87 @@
+"""Test the variable-label-placement gallery example."""
+
+from __future__ import annotations
+
+from maplibreum import Map
+
+
+PLACES = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {"description": "Ford's Theater", "icon": "theatre"},
+            "geometry": {"type": "Point", "coordinates": [-77.038659, 38.931567]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "The Gaslight", "icon": "theatre"},
+            "geometry": {"type": "Point", "coordinates": [-77.003168, 38.894651]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "Horrible Harry's", "icon": "bar"},
+            "geometry": {"type": "Point", "coordinates": [-77.090372, 38.881189]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "Bike Party", "icon": "bicycle"},
+            "geometry": {"type": "Point", "coordinates": [-77.052477, 38.943951]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "Rockabilly Rockstars", "icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.031706, 38.914581]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "District Drum Tribe", "icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.020945, 38.878241]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"description": "Motown Memories", "icon": "music"},
+            "geometry": {"type": "Point", "coordinates": [-77.007481, 38.876516]},
+        },
+    ],
+}
+
+
+def test_variable_label_placement() -> None:
+    """Allow labels to shift using text-variable-anchor and animate the camera."""
+
+    map_instance = Map(
+        map_style="https://tiles.openfreemap.org/styles/bright",
+        center=[-77.04, 38.907],
+        zoom=11.15,
+    )
+
+    map_instance.add_source("places", {"type": "geojson", "data": PLACES})
+    map_instance.add_layer(
+        {
+            "id": "poi-labels",
+            "type": "symbol",
+            "layout": {
+                "text-field": ["get", "description"],
+                "text-font": ["Noto Sans Regular"],
+                "text-variable-anchor": ["top", "bottom", "left", "right"],
+                "text-radial-offset": 0.5,
+                "text-justify": "auto",
+                "icon-image": ["get", "icon"],
+            },
+        },
+        source="places",
+    )
+
+    map_instance.add_on_load_js("map.rotateTo(180, {duration: 10000});")
+
+    assert len(map_instance.layers) == 1
+    layout = map_instance.layers[0]["definition"]["layout"]
+    assert layout["text-field"] == ["get", "description"]
+    assert layout["text-variable-anchor"] == ["top", "bottom", "left", "right"]
+    assert layout["text-radial-offset"] == 0.5
+    assert ["get", "icon"] == layout["icon-image"]
+
+    html = map_instance.render()
+    assert "text-variable-anchor" in html
+    assert "map.rotateTo(180" in html


### PR DESCRIPTION
This commit introduces the `variable-label-placement` example, which demonstrates how to use the `text-variable-anchor` and `text-radial-offset` layout properties to allow labels to dynamically shift their position and avoid overlapping.

Key changes include:
- Creating a new test file `tests/test_examples/test_variable_label_placement.py` to implement the example.
- Updating `misc/maplibre_examples/status.json` to mark the example as complete.
- Updating `misc/maplibre_examples/README.md` to reflect the new coverage status.
- Installing missing dependencies (`IPython`, `pytest`, `jinja2`) required to run the test suite.