### PR TITLE
feat: Implement zoom-and-planet-size-relation-on-globe example

### DIFF
--- a/misc/maplibre_examples/README.md
+++ b/misc/maplibre_examples/README.md
@@ -158,7 +158,7 @@ When converting JavaScript examples to Python:
 
 ### Coverage Summary
 
-**Current Coverage:** 49/123 examples completed
+**Current Coverage:** 50/123 examples completed
 
 - ✅ Ported `add-a-3d-model-to-globe-using-threejs` leveraging the new
   `Map.add_external_script` helper to load three.js dependencies and attach a
@@ -167,6 +167,7 @@ When converting JavaScript examples to Python:
 - ✅ Added `extrude-polygons-for-3d-indoor-mapping` to showcase 3D indoor mapping using the `fill-extrusion-height` paint property.
 - ✅ Implemented `set-center-point-above-ground` by adding `elevation` and `centerClampedToGround` properties to the `Map` constructor, allowing for camera positioning relative to the terrain.
 - ✅ Added `variable-label-placement` to demonstrate dynamic label repositioning using the `text-variable-anchor` and `text-radial-offset` layout properties, preventing label overlap during map interactions.
+- ✅ Implemented `zoom-and-planet-size-relation-on-globe` to show how to compensate for the globe's enlargement near the poles when animating camera movements.
 
 ### Edge-case Validation
 
@@ -193,5 +194,5 @@ While the gallery coverage is exhaustive, a few MapLibre capabilities still requ
 
 We're tracking towards the **123/123 coverage** milestone—complete feature
 parity with the official MapLibre GL JS gallery while preserving a templated,
-reproducible HTML/JS pipeline. Current parity stands at **49/123** with the
+reproducible HTML/JS pipeline. Current parity stands at **50/123** with the
 three.js globe example now automated.

--- a/misc/maplibre_examples/status.json
+++ b/misc/maplibre_examples/status.json
@@ -859,7 +859,7 @@
     "url": "https://maplibre.org/maplibre-gl-js/docs/examples/zoom-and-planet-size-relation-on-globe/",
     "source_status": true,
     "file_path": "misc/maplibre_examples/pages/zoom-and-planet-size-relation-on-globe.html",
-    "task_status": false,
-    "script": null
+    "task_status": true,
+    "script": "tests/test_examples/test_zoom_and_planet_size_relation_on_globe.py"
   }
 }

--- a/tests/test_examples/test_zoom_and_planet_size_relation_on_globe.py
+++ b/tests/test_examples/test_zoom_and_planet_size_relation_on_globe.py
@@ -1,0 +1,44 @@
+from maplibreum import Map
+
+def test_zoom_and_planet_size_relation_on_globe():
+    button_html = '<button id="fly">Go to pole or equator</button>'
+    m = Map(
+        map_style="https://demotiles.maplibre.org/style.json",
+        center=[0, 0],
+        zoom=2,
+        extra_js=f"document.body.insertAdjacentHTML('beforeend', `{button_html}`)",
+    )
+    m.set_projection("globe")
+
+    js_code = f"""
+    const map = {m.map_id};
+
+    function getZoomAdjustment(oldLatitude, newLatitude) {{
+        return Math.log2(Math.cos(newLatitude / 180 * Math.PI) / Math.cos(oldLatitude / 180 * Math.PI));
+    }}
+
+    let zoomIn = false;
+    const zoomDelta = 1.5;
+
+    document.getElementById('fly').addEventListener('click', () => {{
+        const center = [
+            map.getCenter().lng,
+            zoomIn ? 0 : 80,
+        ];
+        const mapZoom = map.getZoom();
+        const delta = (zoomIn ? zoomDelta : -zoomDelta);
+        const zoom = map.getZoom() + delta + getZoomAdjustment(map.getCenter().lat, center[1]);
+        map.flyTo({{
+            center,
+            zoom,
+            essential: true
+        }});
+        zoomIn = !zoomIn;
+    }});
+    """
+
+    m.add_on_load_js(js_code)
+    html = m.render()
+    assert '"projection": "globe"' in html
+    assert "const map =" in html
+    assert "Go to pole or equator" in html


### PR DESCRIPTION
Adds a new test case to reproduce the official MapLibre GL JS example "Zoom and planet size relation on globe".

The implementation uses the existing `maplibreum` API to set the globe projection and injects custom JavaScript to handle the interactive camera animation. The JavaScript logic correctly calculates the required zoom adjustment to compensate for the globe's visual distortion near the poles.

- Updates `status.json` to mark the example as complete.
- Updates the roadmap in `misc/maplibre_examples/README.md` to reflect the new coverage.