### PR TITLE
Optimize PMTiles URL definition in tests

### DIFF
--- a/tests/test_examples/test_pmtiles_source_and_protocol.py
+++ b/tests/test_examples/test_pmtiles_source_and_protocol.py
@@ -10,7 +10,7 @@ STYLE = {
     "sources": {
         "example_source": {
             "type": "vector",
-            "url": "pmtiles://" + PMTILES_ARCHIVE, # TODO: check whether is this the best way to define an url
+            "url": PMTilesSource(archive_url=PMTILES_ARCHIVE).style_url,
             "attribution": '© <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>',
         }
     },
@@ -40,10 +40,10 @@ STYLE = {
 }
 
 
-LEGACY_PROTOCOL_JS = """
+LEGACY_PROTOCOL_JS = f"""
 const protocol = new pmtiles.Protocol();
 maplibregl.addProtocol('pmtiles', protocol.tile);
-const archive = new pmtiles.PMTiles('https://pmtiles.io/protomaps(vector)ODbL_firenze.pmtiles');
+const archive = new pmtiles.PMTiles('{PMTILES_ARCHIVE}');
 protocol.add(archive);
 """
 


### PR DESCRIPTION
Analyzed the PMTiles source URL definition and determined that using the project's `PMTilesSource` abstraction is the optimal approach. Refactored the test file to use `PMTilesSource.style_url` and improved string consistency using f-strings. Verified that the `PMTilesSource` dataclass in `maplibreum/protocols.py` supports these attributes.

---
*PR created automatically by Jules for task [6075045841505853337](https://jules.google.com/task/6075045841505853337) started by @kauevestena*