### PR TITLE
🧪 [Add tests for generic Protocol class]

### DIFF
--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,0 +1,32 @@
+from maplibreum import Map
+from maplibreum.protocols import Protocol
+
+def test_protocol_init():
+    """Test basic initialization of Protocol."""
+    name = "custom"
+    definition = "console.log('custom protocol');"
+    protocol = Protocol(name=name, definition=definition)
+
+    assert protocol.name == name
+    assert protocol.definition == definition
+
+def test_map_add_protocol():
+    """Test registering a Protocol on a Map instance."""
+    m = Map()
+    protocol = Protocol(name="test", definition="// test")
+    m.add_protocol(protocol)
+
+    assert protocol in m.custom_protocols
+
+def test_protocol_rendering():
+    """Test that Protocol is correctly rendered in the HTML template."""
+    m = Map()
+    protocol_name = "my-custom-proto"
+    protocol_def = "return {data: new ArrayBuffer(0)};"
+    protocol = Protocol(name=protocol_name, definition=protocol_def)
+    m.add_protocol(protocol)
+
+    html = m.render()
+
+    assert f"maplibregl.addProtocol('{protocol_name}'" in html
+    assert protocol_def in html


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
This PR addresses the missing tests for the generic `Protocol` class in `maplibreum/protocols.py:52`.

### 📊 Coverage: What scenarios are now tested
- **Initialization**: Verified that `Protocol` instances correctly store `name` and `definition`.
- **Registration**: Verified that `Map.add_protocol()` correctly registers the protocol instance.
- **Rendering**: Verified that `Map.render()` produces the correct JavaScript `maplibregl.addProtocol` call with the expected name and definition in the generated HTML.

### ✨ Result: The improvement in test coverage
Increased test coverage for custom protocol registration, ensuring that generic data loading protocols are correctly initialized and integrated into the rendered MapLibre maps.

---
*PR created automatically by Jules for task [5672518308931280538](https://jules.google.com/task/5672518308931280538) started by @kauevestena*