### PR TITLE
🧹 Remove unused Dict import in realtime.py

### DIFF
--- a/maplibreum/realtime.py
+++ b/maplibreum/realtime.py
@@ -4,7 +4,7 @@ Support for real-time data updates and animations.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict
+from typing import Any
 
 import requests
 


### PR DESCRIPTION
🎯 **What:** Removed an unused `Dict` import from `maplibreum/realtime.py`.
💡 **Why:** Improving code maintainability by removing dead code/unused imports. The codebase prefers built-in types for type hinting.
✅ **Verification:** 
- Verified that `Dict` is not used anywhere else in the file.
- Confirmed syntax is correct using `py_compile`.
- Verified that classes in the module still import correctly (with dependencies mocked where necessary).
✨ **Result:** Cleaner code and slightly reduced overhead.

---
*PR created automatically by Jules for task [16364949166842610093](https://jules.google.com/task/16364949166842610093) started by @kauevestena*