### PR TITLE
⚡ Optimize MarkerCluster.add_marker performance

### DIFF
--- a/maplibreum/cluster.py
+++ b/maplibreum/cluster.py
@@ -24,6 +24,7 @@ class MarkerCluster:
         self.features = []
         self.map = None
         self.source_name = None
+        self._source = None
         self.cluster_layer_id = None
         self.count_layer_id = None
         self.unclustered_layer_id = None
@@ -43,10 +44,14 @@ class MarkerCluster:
         }
         self.features.append(feature)
         if self.map and self.source_name:
-            for src in self.map.sources:
-                if src["name"] == self.source_name:
-                    src["definition"]["data"]["features"] = self.features
-                    break
+            if self._source is None:
+                for src in self.map.sources:
+                    if src["name"] == self.source_name:
+                        self._source = src
+                        break
+
+            if self._source:
+                self._source["definition"]["data"]["features"] = self.features
 
     def add_to(self, map_instance):
         """Add the marker cluster to a map instance.
@@ -73,6 +78,11 @@ class MarkerCluster:
             "clusterMaxZoom": self.cluster_max_zoom,
         }
         map_instance.add_source(self.source_name, source)
+        # Find the source by name to avoid relying on its position in the list
+        for src in map_instance.sources:
+            if src["name"] == self.source_name:
+                self._source = src
+                break
 
         self.cluster_layer_id = f"{self.name}_clusters"
         cluster_layer = {


### PR DESCRIPTION
Optimized the `MarkerCluster.add_marker` method to avoid $O(N)$ linear searches for the cluster's source in the map's source list. Introduced a `self._source` cache that is populated when the cluster is added to the map and utilized during marker additions. This provides a significant performance boost when adding many markers to a map with a large number of sources. Verified the fix with benchmark scripts and functional tests (with mocked dependencies due to environment constraints). addressed code review feedback by ensuring robust source lookup in `add_to` and cleaning up temporary benchmark files.

---
*PR created automatically by Jules for task [14067992127511322135](https://jules.google.com/task/14067992127511322135) started by @kauevestena*