### PR TITLE
🧪 Add tests for haversine_distance and geospatial utilities

### DIFF
--- a/maplibreum/animation.py
+++ b/maplibreum/animation.py
@@ -27,20 +27,19 @@ def calculate_bearing(start: Tuple[float, float], end: Tuple[float, float]) -> f
 
 
 def haversine_distance(
-    coord1: Tuple[float, float], coord2: Tuple[float, float]
+    start: Tuple[float, float], end: Tuple[float, float]
 ) -> float:
-    """Calculate great circle distance between two points in kilometers.
+    """Calculate haversine distance between two points in meters.
 
     Args:
-        coord1: (longitude, latitude) of first point
-        coord2: (longitude, latitude) of second point
-
+        start: (lon, lat) tuple
+        end: (lon, lat) tuple
     Returns:
-        Distance in kilometers
+        Distance in meters
     """
-    R = 6371  # Earth radius in kilometers
-    lon1, lat1 = math.radians(coord1[0]), math.radians(coord1[1])
-    lon2, lat2 = math.radians(coord2[0]), math.radians(coord2[1])
+    R = 6371000  # Earth radius in meters
+    lon1, lat1 = math.radians(start[0]), math.radians(start[1])
+    lon2, lat2 = math.radians(end[0]), math.radians(end[1])
 
     dLat = lat2 - lat1
     dLon = lon2 - lon1

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -1,0 +1,63 @@
+import pytest
+import math
+from maplibreum.animation import haversine_distance, calculate_bearing, interpolate_along_line
+
+def test_haversine_distance_zero():
+    # Same point should have zero distance
+    point = (0.0, 0.0)
+    assert haversine_distance(point, point) == 0.0
+
+def test_haversine_distance_poles():
+    # North pole to South pole is approx 20,000 km
+    north_pole = (0.0, 90.0)
+    south_pole = (0.0, -90.0)
+    # Expected: pi * R = 3.14159... * 6371000
+    expected = math.pi * 6371000
+    assert pytest.approx(haversine_distance(north_pole, south_pole), rel=1e-4) == expected
+
+def test_haversine_distance_known():
+    # London to New York (approx 5570 km)
+    london = (-0.1278, 51.5074)
+    new_york = (-74.0060, 40.7128)
+    distance = haversine_distance(london, new_york)
+    # 5570 km = 5,570,000 meters
+    assert 5500000 < distance < 5600000
+
+def test_haversine_distance_symmetry():
+    a = (12.34, 56.78)
+    b = (90.12, 34.56)
+    assert haversine_distance(a, b) == haversine_distance(b, a)
+
+def test_calculate_bearing_cardinal():
+    start = (0.0, 0.0)
+    north = (0.0, 10.0)
+    east = (10.0, 0.0)
+    south = (0.0, -10.0)
+    west = (-10.0, 0.0)
+
+    assert calculate_bearing(start, north) == 0.0
+    assert calculate_bearing(start, east) == 90.0
+    assert calculate_bearing(start, south) == 180.0
+    assert calculate_bearing(start, west) == 270.0
+
+def test_interpolate_along_line_simple():
+    coords = [(0.0, 0.0), (10.0, 0.0)]
+    steps = 10
+    arc = interpolate_along_line(coords, steps)
+
+    assert len(arc) == steps + 1
+    assert arc[0] == (0.0, 0.0)
+    assert arc[-1] == (10.0, 0.0)
+    # Midpoint should be approx (5, 0)
+    assert pytest.approx(arc[5][0]) == 5.0
+    assert pytest.approx(arc[5][1]) == 0.0
+
+def test_interpolate_along_line_single_point():
+    coords = [(0.0, 0.0)]
+    arc = interpolate_along_line(coords, 10)
+    assert arc == coords
+
+def test_interpolate_along_line_zero_distance():
+    coords = [(0.0, 0.0), (0.0, 0.0)]
+    arc = interpolate_along_line(coords, 10)
+    assert arc == coords


### PR DESCRIPTION
The `haversine_distance` function in `maplibreum/animation.py` was missing tests. I've implemented a full test suite in `tests/test_animation.py` that covers `haversine_distance`, `calculate_bearing`, and `interpolate_along_line`. Additionally, I updated `haversine_distance` to use meters as the unit of measurement and improved its parameter naming as suggested in the task details. verified the changes by running the new tests and ensuring no regressions in the existing test suite.

---
*PR created automatically by Jules for task [17641892935929981382](https://jules.google.com/task/17641892935929981382) started by @kauevestena*