### PR TITLE
Complete PyPI readiness for Maplibreum 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,17 @@ jobs:
             **/pyproject.toml
             **/setup.cfg
       - name: Install dependencies
-        run: |
-          pip install -e .[test]
+        run: pip install -e .[test]
       - name: Run unit and generated-example tests
         run: pytest -m "not browser"
 
   browser:
+    name: browser (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -43,9 +47,10 @@ jobs:
         run: npm install --no-save --prefix .browser-assets maplibre-gl@6.0.0
       - name: Generate example pages
         run: pytest -m "not browser" tests/test_examples
-      - name: Run browser integration tests
+      - name: Validate generated examples in Chromium
         env:
-          MAPLIBREUM_GALLERY_SLUG: display-a-map
+          MAPLIBREUM_GALLERY_SHARD_TOTAL: '8'
+          MAPLIBREUM_GALLERY_SHARD_INDEX: ${{ matrix.shard }}
           MAPLIBREUM_MAPLIBRE_DIST: .browser-assets/node_modules/maplibre-gl/dist
           MAPLIBREUM_SCREENSHOT_DIR: playwright-report/screenshots
         run: pytest -m browser playwright_tests/test_gallery_examples.py
@@ -53,7 +58,46 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: maplibre-6-browser-smoke-screenshot
+          name: maplibre-6-browser-shard-${{ matrix.shard }}
+          path: playwright-report/
+
+  cdn-browser:
+    name: CDN smoke (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: unpkg
+            expected-host: unpkg.com
+            block-primary: ''
+          - name: jsdelivr-fallback
+            expected-host: cdn.jsdelivr.net
+            block-primary: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Install dependencies
+        run: pip install -e .[test]
+      - name: Install Chromium
+        run: python -m playwright install --with-deps chromium
+      - name: Generate minimal example
+        run: pytest -m "not browser" tests/test_examples/test_display_a_map.py
+      - name: Exercise live CDN path
+        env:
+          MAPLIBREUM_GALLERY_SLUG: display-a-map
+          MAPLIBREUM_EXPECT_CDN_HOST: ${{ matrix.expected-host }}
+          MAPLIBREUM_BLOCK_PRIMARY_CDN: ${{ matrix.block-primary }}
+          MAPLIBREUM_SCREENSHOT_DIR: playwright-report/screenshots
+        run: pytest -m browser playwright_tests/test_gallery_examples.py
+      - name: Upload CDN visual evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maplibre-6-cdn-${{ matrix.name }}
           path: playwright-report/
 
   package:
@@ -70,6 +114,29 @@ jobs:
         run: python -m build
       - name: Validate PyPI metadata
         run: twine check --strict dist/*
+      - name: Install wheel in a clean environment and render HTML
+        run: |
+          python -m venv "${RUNNER_TEMP}/maplibreum-wheel-smoke"
+          "${RUNNER_TEMP}/maplibreum-wheel-smoke/bin/python" -m pip install dist/*.whl
+          "${RUNNER_TEMP}/maplibreum-wheel-smoke/bin/python" - <<'PY'
+          from importlib.metadata import version
+          from pathlib import Path
+          from tempfile import TemporaryDirectory
+
+          from maplibreum import MAPLIBRE_VERSION, Map
+
+          assert version("maplibreum") == "0.2.0"
+          assert MAPLIBRE_VERSION == "6.0.0"
+          with TemporaryDirectory() as directory:
+              output = Path(directory) / "smoke.html"
+              map_ = Map(center=[0, 0], zoom=2)
+              map_.add_marker([0, 0], popup="Maplibreum 0.2.0")
+              map_.save(output)
+              html = output.read_text(encoding="utf-8")
+              assert "maplibre-gl@6.0.0" in html
+              assert "window.maplibreumMaps" in html
+              assert output.stat().st_size > 1_000
+          PY
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           with TemporaryDirectory() as directory:
               output = Path(directory) / "smoke.html"
               map_ = Map(center=[0, 0], zoom=2)
-              map_.add_marker([0, 0], popup="Maplibreum 0.2.0")
+              map_.add_marker(coordinates=[0, 0], popup="Maplibreum 0.2.0")
               map_.save(output)
               html = output.read_text(encoding="utf-8")
               assert "maplibre-gl@6.0.0" in html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-30
+
 ### Changed
 - Standardized generated maps on MapLibre GL JS 6.0.0 and its ES module build.
 - Added an independent jsDelivr fallback for the MapLibre runtime and stylesheet.
 - Normalized raw GeoJSON and `__geo_interface__` objects into valid GeoJSON sources.
 - Expanded CI across Python 3.9–3.13 with separate browser, documentation, and package-release gates.
+- Added eight-shard browser validation for all implemented gallery examples.
+- Added live-CDN smoke tests for unpkg and the forced jsDelivr fallback.
+- Added a clean-wheel installation and standalone-render smoke test.
 
 ### Fixed
 - Made every implemented gallery example generate a browser-testable HTML page.
@@ -28,4 +33,6 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Terrain, sky, and fog helpers alongside expression builders for data-driven styling.
 - Event wiring for click, move, and draw callbacks in Jupyter environments.
 
+[Unreleased]: https://github.com/kauevestena/maplibreum_prototype/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/kauevestena/maplibreum_prototype/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/kauevestena/maplibreum_prototype/releases/tag/v0.1.0

--- a/maplibreum/_version.py
+++ b/maplibreum/_version.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/maplibreum/animation.py
+++ b/maplibreum/animation.py
@@ -266,8 +266,9 @@ class AnimatedIcon:
         Returns:
             The ID of the generated icon.
         """
+        js_variable = self.icon_id.replace("-", "_")
         js_code = f"""
-            const {self.icon_id} = {{
+            const {js_variable} = {{
                 width: {self.size},
                 height: {self.size},
                 data: new Uint8Array({self.size} * {self.size} * 4),
@@ -306,7 +307,7 @@ class AnimatedIcon:
                     return true;
                 }}
             }};
-            map.addImage('{self.icon_id}', {self.icon_id}, {{ pixelRatio: 2 }});
+            map.addImage('{self.icon_id}', {js_variable}, {{ pixelRatio: 2 }});
         """
         map_instance.add_on_load_js(js_code)
         return self.icon_id

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -609,10 +609,10 @@ class Map:
         elif isinstance(layer_definition, ThreeLayer):
             layer_id = layer_definition.id
             self.add_external_script(
-                "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.js"
+                "https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.js"
             )
             self.add_external_script(
-                "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/js/loaders/GLTFLoader.js"
+                "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"
             )
             self.add_on_load_js(layer_definition.js_code)
             layer_definition = layer_definition.to_dict()

--- a/maplibreum/core.py
+++ b/maplibreum/core.py
@@ -1343,18 +1343,51 @@ class Map:
 
         self.rtl_text_plugin = plugin_config
 
+    @staticmethod
+    def _normalise_sky_options(options):
+        """Translate legacy Mapbox sky/fog options to MapLibre's root sky spec."""
+
+        aliases = {
+            "sky-atmosphere-color": "sky-color",
+            "sky-atmosphere-halo-color": "horizon-color",
+            "color": "fog-color",
+            "high-color": "horizon-color",
+            "space-color": "sky-color",
+            "horizon-blend": "horizon-fog-blend",
+        }
+        supported = {
+            "sky-color",
+            "sky-horizon-blend",
+            "horizon-color",
+            "horizon-fog-blend",
+            "fog-color",
+            "fog-ground-blend",
+            "atmosphere-blend",
+        }
+        normalised = {}
+        for key, value in (options or {}).items():
+            target = aliases.get(key, key)
+            if target in supported:
+                normalised[target] = value
+        return normalised
+
     def add_sky_layer(self, name="sky", paint=None, layout=None, before=None):
-        """Add a sky layer to the map."""
-        if paint is None:
-            paint = {"sky-type": "atmosphere"}
-        layer_definition = {"id": name, "type": "sky", "paint": paint}
-        if layout:
-            layer_definition["layout"] = layout
-        self.add_layer(layer_definition, before=before)
+        """Configure MapLibre's root sky style.
+
+        The name, layout, and before arguments are retained for API
+        compatibility. MapLibre 6 models sky and atmospheric fog as a root
+        style property rather than as a layer.
+        """
+
+        del name, layout, before
+        sky = self._normalise_sky_options(paint)
+        self.fog = {**(self.fog or {}), **sky}
 
     def set_fog(self, options=None):
-        """Set global fog options for the map."""
-        self.fog = options if options is not None else {}
+        """Configure atmospheric fog using MapLibre's root sky style."""
+
+        fog = self._normalise_sky_options(options)
+        self.fog = {**(self.fog or {}), **fog}
 
     def add_popup(
         self,

--- a/maplibreum/experimental.py
+++ b/maplibreum/experimental.py
@@ -23,9 +23,6 @@ class MapSynchronizer:
         if map_obj is not self._primary_map:
             raise ValueError("MapSynchronizer can only be added to the primary map.")
 
-        map_obj.add_external_script(
-            "https://unpkg.com/@mapbox/mapbox-gl-sync-move@0.3.1"
-        )
         map_obj.add_on_load_js(self._render_js(map_obj))
         map_obj.custom_css = self._render_css()
 

--- a/maplibreum/protocols.py
+++ b/maplibreum/protocols.py
@@ -72,9 +72,9 @@ class FeatureTransformProtocol:
         return f"""
         const url = params.url.replace('{self.name}://', '');
         const [{{ default: Protobuf }}, {{ VectorTile }}, {{ default: tileToProtobuf }}] = await Promise.all([
-            import('https://unpkg.com/pbf@4.0.1/dist/pbf.min.js'),
+            import('https://esm.sh/pbf@4.0.1'),
             import('https://esm.run/@mapbox/vector-tile@2.0.3/index.js'),
-            import('https://esm.run/vt-pbf@3.1.3/index.js'),
+            import('https://esm.sh/vt-pbf@3.1.3'),
         ]);
         const response = await fetch(url);
         const data = await response.arrayBuffer();

--- a/maplibreum/sources.py
+++ b/maplibreum/sources.py
@@ -589,7 +589,7 @@ class VideoOverlay:
             toggle_code = ""
         
         js_code = setup_code + toggle_code + """
-}})();
+})();
 """
         return js_code
     

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -12,7 +12,7 @@
     <link href="https://unpkg.com/maplibregl-minimap/dist/minimap-control.css" rel="stylesheet" onerror="console.warn('Failed to load minimap CSS')" />
     {% endif %}
     {% if include_search %}
-    <link href="https://unpkg.com/@maplibre/maplibre-gl-geocoder@latest/dist/maplibre-gl-geocoder.css" rel="stylesheet" onerror="console.warn('Failed to load geocoder CSS')" />
+    <link href="https://cdn.jsdelivr.net/npm/@maplibre/maplibre-gl-geocoder@1.9.4/dist/maplibre-gl-geocoder.css" rel="stylesheet" onerror="console.warn('Failed to load geocoder CSS')" />
     {% endif %}
     {% if time_dimension %}
     <link href="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.0/dist/leaflet.timedimension.control.min.css" rel="stylesheet" onerror="console.warn('Failed to load time dimension CSS')" />
@@ -114,7 +114,7 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.0/dist/leaflet.timedimension.min.js" onerror="console.warn('Failed to load time dimension')"></script>
     {% endif %}
     {% if include_search %}
-    <script src="https://unpkg.com/@maplibre/maplibre-gl-geocoder@latest/dist/maplibre-gl-geocoder.min.js" onerror="console.warn('Failed to load geocoder')"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@maplibre/maplibre-gl-geocoder@1.9.4/dist/maplibre-gl-geocoder.min.js" onerror="console.warn('Failed to load geocoder')"></script>
     {% endif %}
 </head>
 <body>
@@ -313,6 +313,17 @@
                 return Promise.resolve(undefined);
             }
 
+            _getViewState() {
+                const center = this.map.getCenter();
+                return {
+                    longitude: center.lng,
+                    latitude: center.lat,
+                    zoom: this.map.getZoom(),
+                    bearing: this.map.getBearing(),
+                    pitch: this.map.getPitch(),
+                };
+            }
+
             _buildProps(config, data) {
                 const jsonProps = (config.props && config.props.json) || {};
                 const props = { data };
@@ -350,7 +361,7 @@
                                     customLayer.__deck = new deck.Deck({
                                         gl,
                                         map,
-                                        initialViewState: map.getFreeCameraOptions(),
+                                        initialViewState: this._getViewState(),
                                         layers: [new deck[config.layerType](layerProps)],
                                     });
                                 } catch (error) {
@@ -368,9 +379,11 @@
                             });
                     },
                     render: () => {
-                        if (customLayer.__deck && this.map.getFreeCameraOptions) {
-                            const viewState = this.map.getFreeCameraOptions();
-                            customLayer.__deck.setProps({ viewState });
+                        if (customLayer.__deck) {
+                            customLayer.__deck.setProps({
+                                viewState: this._getViewState(),
+                            });
+                            customLayer.__deck.redraw();
                         }
                     },
                     onRemove: () => {
@@ -989,7 +1002,11 @@ map.on('load', function() {
     map.setTerrain({{ terrain | tojson | safe }});
     {% endif %}
     {% if fog is not none %}
-    map.setFog({{ fog | tojson | safe }});
+    if (typeof map.setFog === 'function') {
+        map.setFog({{ fog | tojson | safe }});
+    } else if (typeof map.setSky === 'function') {
+        map.setSky({{ fog | tojson | safe }});
+    }
     {% endif %}
 
     // Add layers

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -1002,11 +1002,7 @@ map.on('load', function() {
     map.setTerrain({{ terrain | tojson | safe }});
     {% endif %}
     {% if fog is not none %}
-    if (typeof map.setFog === 'function') {
-        map.setFog({{ fog | tojson | safe }});
-    } else if (typeof map.setSky === 'function') {
-        map.setSky({{ fog | tojson | safe }});
-    }
+    map.setSky({{ fog | tojson | safe }});
     {% endif %}
 
     // Add layers

--- a/maplibreum/templates/map_template.html
+++ b/maplibreum/templates/map_template.html
@@ -103,6 +103,19 @@
     <script src="{{ script.src }}"{% for attr, value in script.attributes.items() %}{% if value is sameas(true) %} {{ attr }}{% else %} {{ attr }}="{{ value }}"{% endif %}{% endfor %}></script>
     {% endfor %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
+    <!-- Optional control libraries must load before map initialization. -->
+    {% if include_minimap %}
+    <script src="https://unpkg.com/maplibregl-minimap/dist/minimap-control.js" onerror="console.warn('Failed to load minimap control')"></script>
+    {% endif %}
+    {% if measure_control %}
+    <script src="https://unpkg.com/maplibre-gl-measures@latest/dist/maplibre-gl-measures.js" onerror="console.warn('Failed to load measure control')"></script>
+    {% endif %}
+    {% if time_dimension %}
+    <script src="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.0/dist/leaflet.timedimension.min.js" onerror="console.warn('Failed to load time dimension')"></script>
+    {% endif %}
+    {% if include_search %}
+    <script src="https://unpkg.com/@maplibre/maplibre-gl-geocoder@latest/dist/maplibre-gl-geocoder.min.js" onerror="console.warn('Failed to load geocoder')"></script>
+    {% endif %}
 </head>
 <body>
     <div id="{{ map_id }}">
@@ -1355,19 +1368,6 @@ map.on('load', function() {
         }
     </script>
     
-    <!-- Load additional libraries with fallbacks -->
-    {% if include_minimap %}
-    <script src="https://unpkg.com/maplibregl-minimap/dist/minimap-control.js" onerror="console.warn('Failed to load minimap control')"></script>
-    {% endif %}
-    {% if measure_control %}
-    <script src="https://unpkg.com/maplibre-gl-measures@latest/dist/maplibre-gl-measures.js" onerror="console.warn('Failed to load measure control')"></script>
-    {% endif %}
-    {% if time_dimension %}
-    <script src="https://cdn.jsdelivr.net/npm/leaflet-timedimension@1.1.0/dist/leaflet.timedimension.min.js" onerror="console.warn('Failed to load time dimension')"></script>
-    {% endif %}
-    {% if include_search %}
-    <script src="https://unpkg.com/@maplibre/maplibre-gl-geocoder@latest/dist/maplibre-gl-geocoder.min.js" onerror="console.warn('Failed to load geocoder')"></script>
-    {% endif %}
 </body>
 
 </html>

--- a/maplibreum/templates/sync_maps.js
+++ b/maplibreum/templates/sync_maps.js
@@ -29,9 +29,30 @@ secondaryMaps.push(secondaryMap);
 
 var allMaps = [map].concat(secondaryMaps);
 
-if (typeof syncMaps === 'function') {
-    syncMaps.apply(null, allMaps);
+function syncMaps() {
+    var maps = Array.prototype.slice.call(arguments);
+    var syncing = false;
+    maps.forEach(function(sourceMap) {
+        sourceMap.on('move', function() {
+            if (syncing) { return; }
+            syncing = true;
+            var center = sourceMap.getCenter();
+            maps.forEach(function(targetMap) {
+                if (targetMap !== sourceMap) {
+                    targetMap.jumpTo({
+                        center: center,
+                        zoom: sourceMap.getZoom(),
+                        bearing: sourceMap.getBearing(),
+                        pitch: sourceMap.getPitch()
+                    });
+                }
+            });
+            syncing = false;
+        });
+    });
 }
+
+syncMaps.apply(null, allMaps);
 
 window._maplibreumSyncedMaps = allMaps;
 window._maplibreumSyncedCenter = map.getCenter();

--- a/maplibreum/threejs.py
+++ b/maplibreum/threejs.py
@@ -70,8 +70,8 @@ class ThreeJSLayer:
     def scripts(self) -> list[str]:
         """Returns the list of Three.js scripts required for the layer."""
         return [
-            "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.min.js",
-            "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/js/loaders/GLTFLoader.js",
+            "https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js",
+            "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js",
         ]
 
     def add_to(self, before_layer_id: str = None) -> str:

--- a/playwright_tests/test_gallery_examples.py
+++ b/playwright_tests/test_gallery_examples.py
@@ -241,6 +241,12 @@ def test_rendered_example_loads(
             )
         ]
     assert not console_errors, f"Browser console errors: {console_errors}"
+    if os.environ.get("MAPLIBREUM_BLOCK_PRIMARY_CDN"):
+        failed_requests = [
+            failure
+            for failure in failed_requests
+            if "https://unpkg.com/maplibre-gl@" not in failure
+        ]
     assert not failed_requests, f"Failed browser requests: {failed_requests}"
 
     expected_cdn_host = os.environ.get("MAPLIBREUM_EXPECT_CDN_HOST")

--- a/playwright_tests/test_gallery_examples.py
+++ b/playwright_tests/test_gallery_examples.py
@@ -109,6 +109,7 @@ def test_rendered_example_loads(
     page_errors = []
     console_errors = []
     failed_requests = []
+    successful_responses = []
     page.on("pageerror", lambda error: page_errors.append(str(error)))
     page.on(
         "console",
@@ -122,6 +123,18 @@ def test_rendered_example_loads(
             f"{request.url}: {request.failure or 'request failed'}"
         ),
     )
+    page.on(
+        "response",
+        lambda response: (
+            successful_responses.append(response.url) if response.ok else None
+        ),
+    )
+
+    if os.environ.get("MAPLIBREUM_BLOCK_PRIMARY_CDN"):
+        page.route(
+            "**://unpkg.com/maplibre-gl@*/dist/*",
+            lambda route: route.fulfill(status=503, body="primary CDN blocked by test"),
+        )
 
     maplibre_dist = os.environ.get("MAPLIBREUM_MAPLIBRE_DIST")
     if maplibre_dist:
@@ -221,6 +234,12 @@ def test_rendered_example_loads(
     assert not page_errors, f"Unhandled page errors: {page_errors}"
     assert not console_errors, f"Browser console errors: {console_errors}"
     assert not failed_requests, f"Failed browser requests: {failed_requests}"
+
+    expected_cdn_host = os.environ.get("MAPLIBREUM_EXPECT_CDN_HOST")
+    if expected_cdn_host:
+        assert any(
+            expected_cdn_host in url for url in successful_responses
+        ), f"MapLibre was not loaded successfully from {expected_cdn_host}"
 
     banner_link = page.locator(".maplibreum-example-banner a")
     if metadata.get("url"):

--- a/playwright_tests/test_gallery_examples.py
+++ b/playwright_tests/test_gallery_examples.py
@@ -232,6 +232,14 @@ def test_rendered_example_loads(
         assert map_summary["canvasHeight"] > 0
 
     assert not page_errors, f"Unhandled page errors: {page_errors}"
+    if os.environ.get("MAPLIBREUM_BLOCK_PRIMARY_CDN"):
+        console_errors = [
+            message
+            for message in console_errors
+            if not message.startswith(
+                "Failed to load resource: the server responded with a status of 503"
+            )
+        ]
     assert not console_errors, f"Browser console errors: {console_errors}"
     assert not failed_requests, f"Failed browser requests: {failed_requests}"
 

--- a/tests/test_examples/test_add_a_3d_model_using_threejs.py
+++ b/tests/test_examples/test_add_a_3d_model_using_threejs.py
@@ -18,13 +18,13 @@ def test_add_a_3d_model_using_threejs_configuration():
     )
 
     map_instance.add_external_script(
-        "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.min.js",
+        "https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js",
         defer=True,
     )
     map_instance.add_external_script(
         (
             "https://cdn.jsdelivr.net/"
-            "npm/three@0.169.0/examples/js/loaders/GLTFLoader.js"
+            "npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"
         ),
         defer=True,
     )

--- a/tests/test_examples/test_add_a_new_layer_below_labels.py
+++ b/tests/test_examples/test_add_a_new_layer_below_labels.py
@@ -41,11 +41,11 @@ def test_add_a_new_layer_below_labels():
         },
         paint={"text-color": "#202", "text-halo-color": "#fff"},
     )
-    m.add_layer(symbol_layer.to_dict(), before="waterway-label")
+    m.add_layer(symbol_layer.to_dict(), before="geolines-label")
 
-    assert m.layers[0]["before"] == "waterway-label"
+    assert m.layers[0]["before"] == "geolines-label"
 
     html = m.render()
-    assert "waterway-label" in html
+    assert "geolines-label" in html
     assert "icon-image" in html
     assert "text-field" in html

--- a/tests/test_examples/test_add_a_raster_tile_source.py
+++ b/tests/test_examples/test_add_a_raster_tile_source.py
@@ -13,7 +13,7 @@ def test_add_a_raster_tile_source():
     )
 
     raster_source = sources.RasterSource(
-        tiles="https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png",
+        tiles="https://tile.openstreetmap.org/{z}/{x}/{y}.png",
         tile_size=256,
         max_zoom=16,
     )
@@ -24,7 +24,7 @@ def test_add_a_raster_tile_source():
 
     html = m.render()
     assert '"type": "raster"' in html
-    assert "terrain" in html
+    assert "tile.openstreetmap.org" in html
     assert len(m.layers) == 1
     definition = m.sources[0]["definition"]
     assert definition["maxzoom"] == 16

--- a/tests/test_examples/test_change_building_color_based_on_zoom_level.py
+++ b/tests/test_examples/test_change_building_color_based_on_zoom_level.py
@@ -12,10 +12,28 @@ def test_change_building_color_based_on_zoom_level():
         zoom=15,
     )
 
+    buildings = {
+        "type": "FeatureCollection",
+        "features": [{
+            "type": "Feature",
+            "properties": {"render_height": 80, "render_min_height": 0},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[
+                    [-73.9861, 40.7482],
+                    [-73.9852, 40.7482],
+                    [-73.9852, 40.7488],
+                    [-73.9861, 40.7488],
+                    [-73.9861, 40.7482],
+                ]],
+            },
+        }],
+    }
+    m.add_source("buildings", buildings)
+
     building_layer = layers.FillExtrusionLayer(
         id="3d-buildings",
-        source="composite",
-        source_layer="building",
+        source="buildings",
         minzoom=15,
         paint={
             "fill-extrusion-color": [
@@ -50,7 +68,7 @@ def test_change_building_color_based_on_zoom_level():
             "fill-extrusion-opacity": 0.8,
         },
     )
-    m.add_layer(building_layer.to_dict(), before="waterway-label")
+    m.add_layer(building_layer.to_dict(), before="geolines-label")
 
     html = m.render()
     assert "fill-extrusion-color" in html

--- a/tests/test_examples/test_display_a_globe_with_an_atmosphere.py
+++ b/tests/test_examples/test_display_a_globe_with_an_atmosphere.py
@@ -13,6 +13,9 @@ def test_display_globe_with_atmosphere():
     m.set_fog({"color": "#88c0ff", "high-color": "#ffffff"})
 
     html = m.render()
-    assert '"type": "sky"' in html
-    assert "map.setFog" in html
+    assert '"type": "sky"' not in html
+    assert "map.setSky" in html
+    assert "map.setFog" not in html
+    assert '"fog-color": "#88c0ff"' in html
+    assert '"horizon-color": "#ffffff"' in html
     assert '"projection": {"name": "globe"}' in html

--- a/tests/test_examples/test_fly_to_a_location.py
+++ b/tests/test_examples/test_fly_to_a_location.py
@@ -51,7 +51,7 @@ def test_fly_to_a_location():
     
     # Add the button control to the map using the control system
     # This demonstrates how to properly integrate ButtonControl
-    m.add_control(button, position="top-center")
+    m.add_control(button, position="top-right")
 
     html = m.render()
 

--- a/tests/test_examples/test_sky_fog_terrain.py
+++ b/tests/test_examples/test_sky_fog_terrain.py
@@ -49,8 +49,13 @@ def test_sky_fog_terrain_configuration():
     html = m.render()
     assert "map.setTerrain" in html
     assert '"source": "terrainSource"' in html
-    assert "map.setFog" in html
-    assert '"type": "sky"' in html
+    assert "map.setSky" in html
+    assert "map.setFog" not in html
+    assert '"sky-color": "#000000"' in html
+    assert '"horizon-color": "#245bde"' in html
+    assert '"fog-color": "#88c0ff"' in html
+    assert '"horizon-fog-blend": 0.2' in html
+    assert '"type": "sky"' not in html
     assert "map.addControl(new maplibregl.TerrainControl" in html
     assert "map.addControl(new maplibregl.GlobeControl" in html
     assert '"projection": {"name": "globe"}' in html

--- a/tests/test_examples/test_slowly_fly_to_a_location.py
+++ b/tests/test_examples/test_slowly_fly_to_a_location.py
@@ -79,7 +79,7 @@ def test_slowly_fly_with_button_control():
     )
     
     # Add the button control to the map
-    m.add_control(button, position="top-center")
+    m.add_control(button, position="top-right")
 
     html = m.render()
 

--- a/tests/test_examples/test_sync_movement_of_multiple_maps.py
+++ b/tests/test_examples/test_sync_movement_of_multiple_maps.py
@@ -39,8 +39,6 @@ def test_sync_movement_of_multiple_maps() -> None:
         """
     ).strip()
 
-    map_instance.add_external_script("https://unpkg.com/@mapbox/mapbox-gl-sync-move@0.3.1")
-
     sync_js = textwrap.dedent(
         f"""
         var primaryContainer = document.getElementById('{map_instance.map_id}');
@@ -76,9 +74,30 @@ def test_sync_movement_of_multiple_maps() -> None:
             maplibreLogo: true
         }});
 
-        if (typeof syncMaps === 'function') {{
-            syncMaps(map, map2, map3);
+        function syncMaps() {{
+            var maps = Array.prototype.slice.call(arguments);
+            var syncing = false;
+            maps.forEach(function(sourceMap) {{
+                sourceMap.on('move', function() {{
+                    if (syncing) {{ return; }}
+                    syncing = true;
+                    var center = sourceMap.getCenter();
+                    maps.forEach(function(targetMap) {{
+                        if (targetMap !== sourceMap) {{
+                            targetMap.jumpTo({{
+                                center: center,
+                                zoom: sourceMap.getZoom(),
+                                bearing: sourceMap.getBearing(),
+                                pitch: sourceMap.getPitch()
+                            }});
+                        }}
+                    }});
+                    syncing = false;
+                }});
+            }});
         }}
+
+        syncMaps(map, map2, map3);
 
         window._maplibreumSyncedMaps = [map, map2, map3];
         window._maplibreumSyncedCenter = map.getCenter();
@@ -101,7 +120,7 @@ def test_sync_movement_of_multiple_maps() -> None:
 
     html = map_instance.render()
     assert "syncMaps(map, map2, map3)" in html
-    assert "mapbox-gl-sync-move" in html
+    assert "function syncMaps()" in html
     assert "window._maplibreumSyncedMaps" in html
 
 

--- a/tests/test_examples/test_sync_movement_of_multiple_maps.py
+++ b/tests/test_examples/test_sync_movement_of_multiple_maps.py
@@ -150,7 +150,7 @@ def test_sync_movement_of_multiple_maps_with_python_api() -> None:
     synchronizer.add_to(map_1)
 
     html = map_1.render()
-    assert "mapbox-gl-sync-move" in html
+    assert "function syncMaps()" in html
     assert f"var primaryContainer = document.getElementById('{map_1.map_id}');" in html
     assert "syncMaps.apply(null, allMaps);" in html
     assert f"container: '{map_1.map_id}-secondary-0'" in html

--- a/tests/test_examples/test_toggle_deckgl_layer.py
+++ b/tests/test_examples/test_toggle_deckgl_layer.py
@@ -63,7 +63,7 @@ def test_toggle_deckgl_layer():
     )
 
     m = Map(
-        map_style="https://maps.clockworkmicro.com/streets/v1/style?x-api-key=Dr4eW3s233rRkk8I_public",
+        map_style="https://demotiles.maplibre.org/style.json",
         center=[2.345885, 48.860412],
         zoom=12,
     )
@@ -84,6 +84,6 @@ def test_toggle_deckgl_layer():
     assert 'overlayManager.addOverlay("paris-parks")' in html
     assert 'overlayManager.removeOverlay("paris-parks")' in html
     assert "Deck.GL Parks" in html
-    assert '"style": "https://maps.clockworkmicro.com/streets/v1/style?x-api-key=Dr4eW3s233rRkk8I_public"' in html.replace("\n", "")
+    assert '"style": "https://demotiles.maplibre.org/style.json"' in html.replace("\n", "")
     assert '"center": [2.345885, 48.860412]' in html
     assert '"zoom": 12' in html

--- a/tests/test_terrain_sky_fog.py
+++ b/tests/test_terrain_sky_fog.py
@@ -18,14 +18,24 @@ def test_terrain(map_instance):
 
 
 def test_sky_layer(map_instance):
-    map_instance.add_sky_layer()
+    map_instance.add_sky_layer(
+        paint={
+            "sky-atmosphere-color": "#88c0ff",
+            "sky-atmosphere-halo-color": "#ffffff",
+        }
+    )
     html = map_instance.render()
-    assert any(l["definition"]["type"] == "sky" for l in map_instance.layers)
-    assert '"type": "sky"' in html
+    assert not any(l["definition"]["type"] == "sky" for l in map_instance.layers)
+    assert "map.setSky" in html
+    assert '"sky-color": "#88c0ff"' in html
+    assert '"horizon-color": "#ffffff"' in html
 
 
 def test_fog(map_instance):
-    map_instance.set_fog()
+    map_instance.set_fog({"color": "#88c0ff", "horizon-blend": 0.2})
     html = map_instance.render()
-    assert "setFog" in html
+    assert "map.setSky" in html
+    assert "setFog" not in html
+    assert '"fog-color": "#88c0ff"' in html
+    assert '"horizon-fog-blend": 0.2' in html
 


### PR DESCRIPTION
## What changed

- bumps Maplibreum to 0.2.0 and finalizes the dated changelog entry
- restores eight-shard Chromium validation across all 120 implemented MapLibre examples
- uploads per-shard visual evidence
- adds live unpkg validation and a forced jsDelivr fallback test
- installs the built wheel into a clean virtual environment and generates a standalone MapLibre 6 webmap
- retains strict package metadata, documentation, and Python 3.9–3.13 test gates
- cancels superseded CI runs for future updates

## Browser defects fixed

The expanded matrix exposed and this branch fixes:

- CommonJS-only map synchronization in a browser page
- insertion before a nonexistent style layer
- obsolete Three.js distribution URLs
- invalid center control positions
- an invalid animated-icon JavaScript identifier
- a video-overlay JavaScript closure typo
- geocoder/control script load ordering
- an unavailable CORS-blocked Deck.GL demo style
- expected diagnostics when deliberately forcing the CDN fallback

## Why

PR #251 established a functional MapLibre 6 minimal map, but the final CI revision only browser-tested one example, intercepted CDN delivery with local npm assets, and did not install the built wheel in CI. These checks close those release gaps before publishing to PyPI.

The 13 examples explicitly marked unimplemented remain outside the 0.2.0 scope and are not represented as validated.

## Validation

The clean-wheel installation/render check, strict package metadata, documentation build, Python matrix, primary unpkg smoke, and forced jsDelivr fallback are included as mandatory jobs. GitHub Actions run #711 is the authoritative final browser run for the latest head.

This PR remains draft. No merge or PyPI publication is included.